### PR TITLE
add endpoint to get all Predicates from store

### DIFF
--- a/Hexastore.Rocks/KeyConfig.cs
+++ b/Hexastore.Rocks/KeyConfig.cs
@@ -102,6 +102,12 @@ namespace Hexastore.Rocks
             return KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteP, z, pBytes);
         }
 
+        public static byte[] GetNamePPredicate(string name)
+        {
+            var nameBytes = KeyConfig.GetBytes(name);
+            return KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteP);
+        }
+
         public static byte[] GetNamePKeyPredicateObject(string name, string predicate, TripleObject o)
         {
             var nameBytes = KeyConfig.GetBytes(name);

--- a/Hexastore.Rocks/RocksGraph.cs
+++ b/Hexastore.Rocks/RocksGraph.cs
@@ -291,6 +291,22 @@ namespace Hexastore.Rocks
             return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
         }
 
+        public IEnumerable<string> P()
+        {
+            var pPrefix = KeySegments.GetNamePPredicate(_name);
+            var startP = KeyConfig.ConcatBytes(pPrefix, KeyConfig.ByteZero);
+            var endP = KeyConfig.ConcatBytes(pPrefix, KeyConfig.ByteOne);
+            var predicates = new RocksEnumerable(_db, startP, endP, (it) =>
+            {
+                var key = it.Key();
+                var splits = KeyConfig.Split(key);
+                var nextKey = KeyConfig.ConcatBytes(splits[0], KeyConfig.ByteZero, splits[1], KeyConfig.ByteOne);
+                return it.Seek(nextKey);
+            }).Select(x => x.Predicate);
+
+            return predicates;
+        }
+
         public IEnumerable<Triple> P(string p, Triple c)
         {
             if (c == null) {

--- a/Hexastore.Test/TripleTest.cs
+++ b/Hexastore.Test/TripleTest.cs
@@ -144,6 +144,26 @@ namespace Hexastore.Test
         }
 
         [TestMethod]
+        public void Get_P_Returns()
+        {
+            _set.Assert("s1", "p1", "o1");
+            _set.Assert("s1", "p1", TripleObject.FromData("o1"));
+            _set.Assert("s2", "p1", "c1");
+
+            _set.Assert("s2", "p3", "c2");
+            _set.Assert("s2", "p3", "c3");
+            _set.Assert("s2", "p3", "c3"); // duplicate assert
+
+            _set.Assert("s3", "p5", "c1");
+
+            var p = _set.P().ToArray();
+            Assert.AreEqual(p.Count(), 3);
+            CollectionAssert.Contains(p, "p1");
+            CollectionAssert.Contains(p, "p3");
+            CollectionAssert.Contains(p, "p5");
+        }
+
+        [TestMethod]
         public void GetBy_PO_Returns()
         {
             _set.Assert("s1", "p1", "o1");

--- a/Hexastore.Web/Controllers/StoreController.cs
+++ b/Hexastore.Web/Controllers/StoreController.cs
@@ -68,6 +68,20 @@ namespace Hexastore.Web.Controllers
             }
         }
 
+        [HttpGet("{storeId}/predicates")]
+        public IActionResult Predicates(string storeId)
+        {
+            _logger.LogInformation(LoggingEvents.ControllerPredicates, $"PREDICATES: store {storeId}");
+            try
+            {
+                var rsp = _storeProcessor.GetPredicates(storeId);
+                return Ok(rsp);
+            } catch (Exception e)
+            {
+                return HandleException(e);
+            }
+        }
+
         [HttpPost("{storeId}/ingest")]
         public async Task<IActionResult> Ingest(string storeId, [FromBody]JObject body)
         {

--- a/Hexastore.Web/LoggingEvents.cs
+++ b/Hexastore.Web/LoggingEvents.cs
@@ -16,5 +16,6 @@ namespace Hexastore.Web
         public const int ControllerQuery = 106;
         public const int ControllerDelete = 107;
         public const int ControllerError = 108;
+        public const int ControllerPredicates = 109;
     }
 }

--- a/Hexastore/Graph/DisjointUnion.cs
+++ b/Hexastore/Graph/DisjointUnion.cs
@@ -81,6 +81,11 @@ namespace Hexastore.Graph
             return _read.P(p).Concat(_write.P(p));
         }
 
+        public IEnumerable<string> P()
+        {
+            return _read.P().Concat(_write.P());
+        }
+
         public IEnumerable<Triple> PO(string p, TripleObject o)
         {
             return _read.PO(p, o).Concat(_write.PO(p, o));

--- a/Hexastore/Graph/IGraph.cs
+++ b/Hexastore/Graph/IGraph.cs
@@ -61,6 +61,11 @@ namespace Hexastore.Graph
         IEnumerable<Triple> P(string p);
 
         /// <summary>
+        /// P returns all the predicates
+        /// </summary>
+        IEnumerable<string> P();
+
+        /// <summary>
         /// O returns all the triples with this object
         /// </summary>
         IEnumerable<Triple> O(TripleObject o);

--- a/Hexastore/Graph/MemoryGraph.cs
+++ b/Hexastore/Graph/MemoryGraph.cs
@@ -144,6 +144,10 @@ namespace Hexastore.Graph
                 }
             }
         }
+        public IEnumerable<string> P()
+        {
+            return _pos.Keys;
+        }
 
         public IEnumerable<Triple> PO(string tp, TripleObject to)
         {

--- a/Hexastore/Processor/IStoreProcesor.cs
+++ b/Hexastore/Processor/IStoreProcesor.cs
@@ -16,5 +16,6 @@ namespace Hexastore.Processor
         JObject GetSubject(string storeId, string subject, string[] expand, int level);
         JObject GetType(string storeId, string[] type, string[] expand, int level);
         JObject Query(string storeId, JObject query, string[] expand, int level);
+        JObject GetPredicates(string storeId);
     }
 }

--- a/Hexastore/Processor/StoreProcessor.cs
+++ b/Hexastore/Processor/StoreProcessor.cs
@@ -189,6 +189,18 @@ namespace Hexastore.Processor
             }
         }
 
+        public JObject GetPredicates(string storeId)
+        {
+            using (var op = _storeOperationFactory.Read(storeId))
+            {
+                var (data, _, _) = GetSetGraphs(storeId);
+                var predicates = data.P().ToList();
+                return new JObject {
+                    new JProperty("values", new JArray(predicates))
+                };
+            }
+        }
+
         public JObject GetType(string storeId, string[] type, string[] expand, int level)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Adds a new endpoint to fetch all Predicates from the store and return an object with `values` property containing an array of the predicates in string format.

Note: there currently is no pagination or prefixing for this endpoint (or support for it within the store) so may be worth adding for stores with larger predicate counts. 