### PR TITLE
Move libraries to netstandard2.0

### DIFF
--- a/Hexastore.Rocks/Hexastore.Rocks.csproj
+++ b/Hexastore.Rocks/Hexastore.Rocks.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Hexastore.Rocks/RocksGraph.cs
+++ b/Hexastore.Rocks/RocksGraph.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
-using System.Text;
 using Hexastore.Graph;
 using RocksDbSharp;
 

--- a/Hexastore.Rocks/RocksTest.cs
+++ b/Hexastore.Rocks/RocksTest.cs
@@ -8,7 +8,7 @@ namespace Hexastore.Rocks
     {
         public RocksTest()
         {
-            var dataPath = Path.GetRelativePath(".", "rockstest");
+            var dataPath = Path.Combine(Path.GetFullPath("."), "rockstest");
             if (Directory.Exists(dataPath)) {
                 Directory.Delete(dataPath, true);
             }

--- a/Hexastore.Rocks/TripleExtensions.cs
+++ b/Hexastore.Rocks/TripleExtensions.cs
@@ -53,10 +53,11 @@ namespace Hexastore.Rocks
 
             var s = GetString(sBytes);
             var p = GetString(pBytes);
-            var arrayIndex = BitConverter.ToInt32(arrayIndexBytes);
+
+            var arrayIndex = BitConverter.ToInt32(arrayIndexBytes, 0);
             var ovalue = GetString(oBytes);
             var id = idBytes[0] == 1 ? true : false;
-            var type = (JTokenType)BitConverter.ToUInt16(oTypeBytes);
+            var type = (JTokenType)BitConverter.ToUInt16(oTypeBytes, 0);
             return new Triple(s, p, new TripleObject(ovalue, id, type, arrayIndex));
         }
 

--- a/Hexastore.Web/Hexastore.Web.csproj
+++ b/Hexastore.Web/Hexastore.Web.csproj
@@ -21,8 +21,6 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.0.2105168" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="RocksDbNative" Version="5.17.2" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
   </ItemGroup>
 

--- a/Hexastore/Hexastore.csproj
+++ b/Hexastore/Hexastore.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Hexastore/Query/ObjectQueryExecutor.cs
+++ b/Hexastore/Query/ObjectQueryExecutor.cs
@@ -14,6 +14,7 @@ namespace Hexastore.Query
     public class ObjectQueryExecutor
     {
         private readonly StoreError _storeErrors;
+        private static readonly char[] LinkDelimiterArray = Constants.LinkDelimeter.ToCharArray();
 
         public ObjectQueryExecutor()
         {
@@ -197,7 +198,7 @@ namespace Hexastore.Query
                 throw _storeErrors.PathEmpty;
             }
 
-            var paths = link.Path.Split(Constants.LinkDelimeter);
+            var paths = link.Path.Split(LinkDelimiterArray);
 
             var matched = source.Where(x =>
             {
@@ -224,7 +225,7 @@ namespace Hexastore.Query
                 throw _storeErrors.PathEmpty;
             }
 
-            var paths = link.Path.Split(Constants.LinkDelimeter).Reverse();
+            var paths = link.Path.Split(LinkDelimiterArray).Reverse();
 
             var matched = source.Where(x =>
             {

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+    <disabledPackageSources>
+        <clear />
+    </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
Move libraries to netstandard2.0

* Fix misc calls where helpers do not exist in netstandard2.0
* Add NuGet.Config to avoid referencing unneeded sources from the machine config

This is a subset of the netcoreapp3.1 PR. It contains only the cleanup/netstandard changes. It will make it easier to move to netcoreapp3.1 later, and allow the non-web part of Hexastore to be used anywhere.