### PR TITLE
Add Hexastore.PerfConsole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/data/
 **/out/
 *.env
+**/BenchmarkDotNet.Artifacts/
 
 # User-specific files
 *.suo

--- a/Hexastore.PerfConsole/Hexastore.PerfConsole.csproj
+++ b/Hexastore.PerfConsole/Hexastore.PerfConsole.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <NoWarn>NU1608</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Hexastore.Web\Hexastore.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Hexastore.PerfConsole/JsonGenerator.cs
+++ b/Hexastore.PerfConsole/JsonGenerator.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Hexastore.PerfConsole
+{
+    public static class JsonGenerator
+    {
+        public static JObject GenerateTelemetry(string id, Dictionary<string, double> numberValues)
+        {
+            return new JObject(new JProperty("id", id),
+                numberValues.Select(e => new JProperty(e.Key, e.Value)));
+        }
+
+        public static JObject GenerateTelemetry(string id, Dictionary<string, double> numberValues, Dictionary<string, string> stringValues)
+        {
+            return new JObject(new JProperty("id", id),
+                numberValues.Select(e => new JProperty(e.Key, e.Value)),
+                stringValues.Select(e => new JProperty(e.Key, e.Value)));
+        }
+    }
+}

--- a/Hexastore.PerfConsole/PatchAddNew.cs
+++ b/Hexastore.PerfConsole/PatchAddNew.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Hexastore.Processor;
+using Hexastore.Resoner;
+using Hexastore.Rocks;
+using Hexastore.TestCommon;
+using Microsoft.Extensions.Logging;
+
+namespace Hexastore.PerfConsole
+{
+    /**
+     * Add only new telemetry to the db using Patch
+     * 
+     * A new database will be created for each invocation.
+     */
+    [SimpleJob(RunStrategy.Monitoring, invocationCount: 20)]
+    public class PatchAddNew
+    {
+        private List<string> _ids = new List<string>();
+        private List<string> _dataPoints = new List<string>();
+        private const int _maxIds = 1000;
+        private const int _maxPoints = 20;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            while (_ids.Count < _maxIds)
+            {
+                _ids.Add(Guid.NewGuid().ToString());
+            }
+
+            while (_dataPoints.Count < _maxPoints)
+            {
+                _dataPoints.Add(Guid.NewGuid().ToString());
+            }
+        }
+
+        [Benchmark]
+        public void RunTest()
+        {
+            using (var testFolder = new TestFolder())
+            {
+                var factory = new LoggerFactory();
+                var logger = factory.CreateLogger<RocksGraphProvider>();
+                var storeLogger = factory.CreateLogger<StoreProcessor>();
+                var provider = new RocksGraphProvider(logger, testFolder);
+                var storeProvider = new SetProvider(provider);
+                var storeOperationFactory = new StoreOperationFactory();
+                var storeProcessor = new StoreProcessor(storeProvider, new Reasoner(), storeOperationFactory, storeLogger);
+
+
+                var storeId = "test";
+                var points = new Dictionary<string, double>();
+                var pointCount = 0;
+                foreach (var pointId in _dataPoints)
+                {
+                    pointCount++;
+                    points.Add(pointId, pointCount + 0.234);
+                }
+
+                foreach (var id in _ids)
+                {
+                    var json = JsonGenerator.GenerateTelemetry(id, points);
+                    storeProcessor.PatchJson(storeId, json);
+                }
+            }
+        }
+    }
+}

--- a/Hexastore.PerfConsole/PatchUpdate.cs
+++ b/Hexastore.PerfConsole/PatchUpdate.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Hexastore.Processor;
+using Hexastore.Resoner;
+using Hexastore.Rocks;
+using Hexastore.TestCommon;
+using Microsoft.Extensions.Logging;
+
+namespace Hexastore.PerfConsole
+{
+    /**
+     * Create a single database for all invocations.
+     * 
+     * Update multiple ids changing the telemetry data points on each patch.
+     */
+    [SimpleJob(RunStrategy.Monitoring, invocationCount: 20)]
+    public class PatchUpdate
+    {
+        private TestFolder _testFolder;
+        private StoreProcessor _storeProcessor;
+        private List<string> _ids = new List<string>();
+        private List<string> _dataPoints = new List<string>();
+        private const int _updateCount = 50;
+        private const int _maxIds = 10;
+        private const int _maxPoints = 3;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _testFolder = new TestFolder();
+            
+            while (_ids.Count < _maxIds)
+            {
+                _ids.Add(Guid.NewGuid().ToString());
+            }
+
+            while (_dataPoints.Count < _maxPoints)
+            {
+                _dataPoints.Add(Guid.NewGuid().ToString());
+            }
+
+            var factory = new LoggerFactory();
+            var logger = factory.CreateLogger<RocksGraphProvider>();
+            var storeLogger = factory.CreateLogger<StoreProcessor>();
+            var provider = new RocksGraphProvider(logger, _testFolder);
+            var storeProvider = new SetProvider(provider);
+            var storeOperationFactory = new StoreOperationFactory();
+            _storeProcessor = new StoreProcessor(storeProvider, new Reasoner(), storeOperationFactory, storeLogger);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _testFolder.Dispose();
+        }
+
+        [Benchmark]
+        public void RunTest()
+        {
+            var storeId = "test";
+            var points = new Dictionary<string, double>();
+            var pointCount = 0;
+            foreach (var pointId in _dataPoints)
+            {
+                pointCount++;
+                points.Add(pointId, pointCount + 0.234);
+            }
+            int x = 0;
+
+            for (var i = 0; i < _updateCount; i++)
+            {
+                foreach (var id in _ids)
+                {
+                    x++;
+
+                    foreach (var key in _dataPoints)
+                    {
+                        points[key] += x;
+                    }
+
+                    var json = JsonGenerator.GenerateTelemetry(id, points);
+                    _storeProcessor.PatchJson(storeId, json);
+                }
+            }
+        }
+    }
+}

--- a/Hexastore.PerfConsole/PatchUpdateNoChange.cs
+++ b/Hexastore.PerfConsole/PatchUpdateNoChange.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Hexastore.Processor;
+using Hexastore.Resoner;
+using Hexastore.Rocks;
+using Hexastore.TestCommon;
+using Microsoft.Extensions.Logging;
+
+namespace Hexastore.PerfConsole
+{
+    /**
+     * Create a single database for all invocations.
+     * 
+     * Repeat the same telemetry data multiple times.
+     */
+    [SimpleJob(RunStrategy.Monitoring, invocationCount: 20)]
+    public class PatchUpdateNoChange
+    {
+        private TestFolder _testFolder;
+        private StoreProcessor _storeProcessor;
+        private List<string> _ids = new List<string>();
+        private List<string> _dataPoints = new List<string>();
+        private const int _updateCount = 200;
+        private const int _maxIds = 10;
+        private const int _maxPoints = 3;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _testFolder = new TestFolder();
+            
+            while (_ids.Count < _maxIds)
+            {
+                _ids.Add(Guid.NewGuid().ToString());
+            }
+
+            while (_dataPoints.Count < _maxPoints)
+            {
+                _dataPoints.Add(Guid.NewGuid().ToString());
+            }
+
+            var factory = new LoggerFactory();
+            var logger = factory.CreateLogger<RocksGraphProvider>();
+            var storeLogger = factory.CreateLogger<StoreProcessor>();
+            var provider = new RocksGraphProvider(logger, _testFolder);
+            var storeProvider = new SetProvider(provider);
+            var storeOperationFactory = new StoreOperationFactory();
+            _storeProcessor = new StoreProcessor(storeProvider, new Reasoner(), storeOperationFactory, storeLogger);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _testFolder.Dispose();
+        }
+
+        [Benchmark]
+        public void RunTest()
+        {
+            var storeId = "test";
+            var points = new Dictionary<string, double>();
+            var pointCount = 0;
+            foreach (var pointId in _dataPoints)
+            {
+                pointCount++;
+                points.Add(pointId, pointCount + 0.234);
+            }
+
+            for (var i = 0; i < _updateCount; i++)
+            {
+                foreach (var id in _ids)
+                {
+                    var json = JsonGenerator.GenerateTelemetry(id, points);
+                    _storeProcessor.PatchJson(storeId, json);
+                }
+            }
+        }
+    }
+}

--- a/Hexastore.PerfConsole/PatchUpdateSingle.cs
+++ b/Hexastore.PerfConsole/PatchUpdateSingle.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Hexastore.Processor;
+using Hexastore.Resoner;
+using Hexastore.Rocks;
+using Hexastore.TestCommon;
+using Microsoft.Extensions.Logging;
+
+namespace Hexastore.PerfConsole
+{
+    /**
+     * Create a single database for all invocations.
+     * 
+     * Update telemetry for only 1 id.
+     */
+    [SimpleJob(RunStrategy.Monitoring, invocationCount: 20)]
+    public class PatchUpdateSingle
+    {
+        private TestFolder _testFolder;
+        private StoreProcessor _storeProcessor;
+        private List<string> _ids = new List<string>();
+        private List<string> _dataPoints = new List<string>();
+        private const int _updateCount = 100;
+        private const int _maxIds = 1;
+        private const int _maxPoints = 10;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _testFolder = new TestFolder();
+            
+            while (_ids.Count < _maxIds)
+            {
+                _ids.Add(Guid.NewGuid().ToString());
+            }
+
+            while (_dataPoints.Count < _maxPoints)
+            {
+                _dataPoints.Add(Guid.NewGuid().ToString());
+            }
+
+            var factory = new LoggerFactory();
+            var logger = factory.CreateLogger<RocksGraphProvider>();
+            var storeLogger = factory.CreateLogger<StoreProcessor>();
+            var provider = new RocksGraphProvider(logger, _testFolder);
+            var storeProvider = new SetProvider(provider);
+            var storeOperationFactory = new StoreOperationFactory();
+            _storeProcessor = new StoreProcessor(storeProvider, new Reasoner(), storeOperationFactory, storeLogger);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _testFolder.Dispose();
+        }
+
+        [Benchmark]
+        public void RunTest()
+        {
+            var storeId = "test";
+            var points = new Dictionary<string, double>();
+            var pointCount = 0;
+            foreach (var pointId in _dataPoints)
+            {
+                pointCount++;
+                points.Add(pointId, pointCount + 0.234);
+            }
+            int x = 0;
+
+            for (var i = 0; i < _updateCount; i++)
+            {
+                foreach (var id in _ids)
+                {
+                    x++;
+
+                    foreach (var key in _dataPoints)
+                    {
+                        points[key] += x;
+                    }
+
+                    var json = JsonGenerator.GenerateTelemetry(id, points);
+                    _storeProcessor.PatchJson(storeId, json);
+                }
+            }
+        }
+    }
+}

--- a/Hexastore.PerfConsole/Program.cs
+++ b/Hexastore.PerfConsole/Program.cs
@@ -1,0 +1,18 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Hexastore.PerfConsole
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // These can be executed with:
+            // dotnet run -c Release
+            // Results will be in Hexastore.PerfConsole\BenchmarkDotNet.Artifacts\results
+            BenchmarkRunner.Run<PatchAddNew>();
+            BenchmarkRunner.Run<PatchUpdate>();
+            BenchmarkRunner.Run<PatchUpdateSingle>();
+            BenchmarkRunner.Run<PatchUpdateNoChange>();
+        }
+    }
+}

--- a/Hexastore.PerfConsole/TestFolder.cs
+++ b/Hexastore.PerfConsole/TestFolder.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+
+namespace Hexastore.TestCommon
+{
+    /// <summary>
+    /// Temp directory that cleans up on dispose.
+    /// </summary>
+    public class TestFolder : IDisposable
+    {
+        // The actual root
+        private readonly DirectoryInfo _parent;
+
+        public string Root => RootDirectory.FullName;
+
+        /// <summary>
+        /// Delete the directory after completion.
+        /// </summary>
+        public bool CleanUp { get; set; } = true;
+
+        /// <summary>
+        /// Root directory, parent of the working directory
+        /// </summary>
+        public DirectoryInfo RootDirectory { get; }
+
+        public TestFolder()
+        {
+            var parts = Guid.NewGuid().ToString().ToLowerInvariant().Split('-');
+
+            _parent = new DirectoryInfo(Path.Combine(Path.GetTempPath(), parts[0]));
+            _parent.Create();
+
+            File.WriteAllText(Path.Combine(_parent.FullName, "trace.txt"), Environment.StackTrace);
+
+            RootDirectory = new DirectoryInfo(Path.Combine(_parent.FullName, parts[1]));
+            RootDirectory.Create();
+        }
+
+        public static implicit operator string(TestFolder folder)
+        {
+            return folder.Root;
+        }
+
+        public override string ToString()
+        {
+            return Root;
+        }
+
+        public void Dispose()
+        {
+            if (CleanUp)
+            {
+                try
+                {
+                    _parent.Delete(true);
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+}

--- a/Hexastore.sln
+++ b/Hexastore.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hexastore.PerfConsole", "Hexastore.PerfConsole\Hexastore.PerfConsole.csproj", "{A657D874-2D65-4823-A9FC-1B2B867C56A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +42,10 @@ Global
 		{446D86FC-60E2-4467-BFC8-AE0A22BC38B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{446D86FC-60E2-4467-BFC8-AE0A22BC38B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{446D86FC-60E2-4467-BFC8-AE0A22BC38B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A657D874-2D65-4823-A9FC-1B2B867C56A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A657D874-2D65-4823-A9FC-1B2B867C56A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A657D874-2D65-4823-A9FC-1B2B867C56A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A657D874-2D65-4823-A9FC-1B2B867C56A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
* Use BenchmarkDotNet to measure patch scenarios

``dotnet run -c Release`` in *Hexastore.PerfConsole* will run all perf tests and output the results to *Hexastore.PerfConsole /BenchmarkDotNet.Artifacts*

The current test contain a few simple patch scenarios. BenchmarkDotnet runs each test 20 times and outputs the mean time it took.

The results are machine specific. When making a perf change runs the tests against the branch with the change, and then against the master branch to get a comparison.