### PR TITLE
Optimize PATCH operations to avoid scan

### DIFF
--- a/Hexastore.Rocks/KeyConfig.cs
+++ b/Hexastore.Rocks/KeyConfig.cs
@@ -38,7 +38,7 @@ namespace Hexastore.Rocks
         {
             if (_sKey == null) {
                 var z = KeyConfig.ByteZero;
-                _sKey = KeyConfig.ConcatBytes(_name, KeyConfig.ByteS, z, S, z, P, z, Index, z, IsId, z, O);
+                _sKey = KeyConfig.ConcatBytes(_name, KeyConfig.ByteS, z, S, z, P, z, Index);
                 _pKey = KeyConfig.ConcatBytes(_name, KeyConfig.ByteP, z, P, z, IsId, z, O, z, Index, z, S);
                 _oKey = KeyConfig.ConcatBytes(_name, KeyConfig.ByteO, z, IsId, z, O, z, S, z, P, z, Index);
             }
@@ -72,6 +72,16 @@ namespace Hexastore.Rocks
             var sBytes = KeyConfig.GetBytes(subject);
             var pBytes = KeyConfig.GetBytes(predicate);
             return KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteS, z, sBytes, z, pBytes);
+        }
+
+        public static byte[] GetNameSKeySubjectPredicateIndex(string name, string subject, string predicate, int index)
+        {
+            var nameBytes = KeyConfig.GetBytes(name);
+            var z = KeyConfig.ByteZero;
+            var sBytes = KeyConfig.GetBytes(subject);
+            var pBytes = KeyConfig.GetBytes(predicate);
+            var indexBytes = BitConverter.GetBytes(index);
+            return KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteS, z, sBytes, z, pBytes, z, indexBytes);
         }
 
         public static byte[] GetNameOKeyObject(string name, TripleObject o)

--- a/Hexastore.Rocks/RocksGraph.cs
+++ b/Hexastore.Rocks/RocksGraph.cs
@@ -8,17 +8,16 @@ namespace Hexastore.Rocks
 {
     public class RocksGraph : IStoreGraph
     {
-        private readonly string _name;
         private readonly RocksDb _db;
         private static readonly WriteOptions _writeOptions = (new WriteOptions()).SetSync(false);
 
         public RocksGraph(string name, RocksDb db)
         {
-            _name = name;
+            Name = name;
             _db = db;
         }
 
-        public string Name => _name;
+        public string Name { get; }
 
         public int Count => throw new System.NotImplementedException();
 
@@ -28,7 +27,7 @@ namespace Hexastore.Rocks
                 return false;
             }
 
-            var (sKey, pKey, oKey) = new KeySegments(_name, t.Subject, t.Predicate, t.Object).GetKeys();
+            var (sKey, pKey, oKey) = new KeySegments(Name, t.Subject, t.Predicate, t.Object).GetKeys();
 
             var serializedTriple = t.ToBytes();
             using (var batch = new WriteBatch()) {
@@ -48,7 +47,7 @@ namespace Hexastore.Rocks
                         continue;
                     }
 
-                    var (sKey, pKey, oKey) = new KeySegments(_name, t.Subject, t.Predicate, t.Object).GetKeys();
+                    var (sKey, pKey, oKey) = new KeySegments(Name, t.Subject, t.Predicate, t.Object).GetKeys();
                     var serializedTriple = t.ToBytes();
 
                     batch.Put(sKey, serializedTriple);
@@ -68,7 +67,7 @@ namespace Hexastore.Rocks
         {
             using (var batch = new WriteBatch()) {
                 foreach (var t in retract) {
-                    var (sKey, pKey, oKey) = new KeySegments(_name, t.Subject, t.Predicate, t.Object).GetKeys();
+                    var (sKey, pKey, oKey) = new KeySegments(Name, t.Subject, t.Predicate, t.Object).GetKeys();
 
                     batch.Delete(sKey);
                     batch.Delete(pKey);
@@ -76,7 +75,7 @@ namespace Hexastore.Rocks
                 }
 
                 foreach (var t in assert) {
-                    var (sKey, pKey, oKey) = new KeySegments(_name, t.Subject, t.Predicate, t.Object).GetKeys();
+                    var (sKey, pKey, oKey) = new KeySegments(Name, t.Subject, t.Predicate, t.Object).GetKeys();
                     var serializedTriple = t.ToBytes();
 
                     batch.Put(sKey, serializedTriple);
@@ -103,17 +102,17 @@ namespace Hexastore.Rocks
 
         public bool Exists(string s, string p, TripleObject o)
         {
-            var keySegments = new KeySegments(_name, s, p, o);
+            var keySegments = new KeySegments(Name, s, p, o);
             var oPrefix = keySegments.GetOPrefix();
             var start = KeyConfig.ConcatBytes(oPrefix, KeyConfig.ByteZero);
             var end = KeyConfig.ConcatBytes(oPrefix, KeyConfig.ByteOne);
             var oEnumerable = new RocksEnumerable(_db, start, end, (it) => it.Next());
-            return oEnumerable.Any();
+            return oEnumerable.Any(x => x.Predicate == p);
         }
 
         public IEnumerable<IGrouping<string, IGrouping<string, TripleObject>>> GetGroupings()
         {
-            var nameBytes = KeySegments.GetNameSKey(_name);
+            var nameBytes = KeySegments.GetNameSKey(Name);
             var start = KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteZero);
             var end = KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteOne);
             var subjects = new RocksEnumerable(_db, start, end, (it) =>
@@ -125,25 +124,25 @@ namespace Hexastore.Rocks
             }).Select(x => x.Subject);
 
             foreach (var s in subjects) {
-                var sh = KeySegments.GetNameSKeySubject(_name, s);
+                var sh = KeySegments.GetNameSKeySubject(Name, s);
                 var startS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteZero);
                 var endS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteOne);
 
-                yield return new RocksSubjectGrouping(_db, _name, s, startS, endS);
+                yield return new RocksSubjectGrouping(_db, Name, s, startS, endS);
             }
         }
 
         public IEnumerable<IGrouping<string, TripleObject>> GetSubjectGroupings(string s)
         {
-            var sh = KeySegments.GetNameSKeySubject(_name, s);
+            var sh = KeySegments.GetNameSKeySubject(Name, s);
             var startS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteOne);
-            return new RocksSubjectGrouping(_db, _name, s, startS, endS);
+            return new RocksSubjectGrouping(_db, Name, s, startS, endS);
         }
 
         public IEnumerable<Triple> GetTriples()
         {
-            var nameBytes = KeySegments.GetNameSKey(_name);
+            var nameBytes = KeySegments.GetNameSKey(Name);
             var start = KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteZero);
             var end = KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteOne);
             return new RocksEnumerable(_db, start, end, (Iterator it) => { return it.Next(); });
@@ -165,7 +164,7 @@ namespace Hexastore.Rocks
 
         public IEnumerable<Triple> S(string s)
         {
-            var sh = KeySegments.GetNameSKeySubject(_name, s);
+            var sh = KeySegments.GetNameSKeySubject(Name, s);
             var startS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteOne);
             return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
@@ -173,12 +172,12 @@ namespace Hexastore.Rocks
 
         public IEnumerable<Triple> S(string s, Triple c)
         {
-            var sh = KeySegments.GetNameSKeySubject(_name, s);
+            var sh = KeySegments.GetNameSKeySubject(Name, s);
             var startS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteOne);
 
             // todo: optimize
-            var (sKey, _, _) = new KeySegments(_name, c).GetKeys();
+            var (sKey, _, _) = new KeySegments(Name, c).GetKeys();
 
             var continuation = KeyConfig.ConcatBytes(sKey, KeyConfig.ByteOne);
 
@@ -193,20 +192,27 @@ namespace Hexastore.Rocks
 
         public IEnumerable<Triple> SP(string s, string p)
         {
-            var sh = KeySegments.GetNameSKeySubjectPredicate(_name, s, p);
+            var sh = KeySegments.GetNameSKeySubjectPredicate(Name, s, p);
             var startS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteOne);
             return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
         }
 
+        public Triple SPI(string s, string p, int index)
+        {
+            var sh = KeySegments.GetNameSKeySubjectPredicateIndex(Name, s, p, index);
+            var t = _db.Get(sh);
+            return t?.ToTriple();
+        }
+
         public IEnumerable<Triple> SP(string s, string p, Triple c)
         {
-            var sh = KeySegments.GetNameSKeySubjectPredicate(_name, s, p);
+            var sh = KeySegments.GetNameSKeySubjectPredicate(Name, s, p);
             var startS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteOne);
 
             // todo: optimize
-            var (sKey, _, _) = new KeySegments(_name, c).GetKeys();
+            var (sKey, _, _) = new KeySegments(Name, c).GetKeys();
             var continuation = KeyConfig.ConcatBytes(sKey, KeyConfig.ByteOne);
 
             if (KeyConfig.ByteCompare(continuation, startS) < 0) {
@@ -220,7 +226,7 @@ namespace Hexastore.Rocks
 
         public IEnumerable<Triple> O(TripleObject o)
         {
-            var oh = KeySegments.GetNameOKeyObject(_name, o);
+            var oh = KeySegments.GetNameOKeyObject(Name, o);
             var startS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteOne);
 
@@ -233,11 +239,11 @@ namespace Hexastore.Rocks
                 return O(o);
             }
 
-            var oh = KeySegments.GetNameOKeyObject(_name, o);
+            var oh = KeySegments.GetNameOKeyObject(Name, o);
             var startS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteOne);
 
-            var (_, _, oKey) = new KeySegments(_name, c).GetKeys();
+            var (_, _, oKey) = new KeySegments(Name, c).GetKeys();
             var continuation = KeyConfig.ConcatBytes(oKey, KeyConfig.ByteOne);
 
             if (KeyConfig.ByteCompare(continuation, startS) < 0) {
@@ -251,7 +257,7 @@ namespace Hexastore.Rocks
 
         public IEnumerable<Triple> OS(TripleObject o, string s)
         {
-            var oh = KeySegments.GetNameOKeyObjectSubject(_name, o, s);
+            var oh = KeySegments.GetNameOKeyObjectSubject(Name, o, s);
             var startS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteOne);
 
@@ -263,11 +269,11 @@ namespace Hexastore.Rocks
             if (c == null) {
                 return OS(o, s);
             }
-            var oh = KeySegments.GetNameOKeyObjectSubject(_name, o, s);
+            var oh = KeySegments.GetNameOKeyObjectSubject(Name, o, s);
             var startS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteOne);
 
-            var (_, _, oKey) = new KeySegments(_name, c).GetKeys();
+            var (_, _, oKey) = new KeySegments(Name, c).GetKeys();
             var continuation = KeyConfig.ConcatBytes(oKey, KeyConfig.ByteOne);
 
             if (KeyConfig.ByteCompare(continuation, startS) < 0) {
@@ -280,7 +286,7 @@ namespace Hexastore.Rocks
 
         public IEnumerable<Triple> P(string p)
         {
-            var ph = KeySegments.GetNamePKeyPredicate(_name, p);
+            var ph = KeySegments.GetNamePKeyPredicate(Name, p);
             var startS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteOne);
 
@@ -289,7 +295,7 @@ namespace Hexastore.Rocks
 
         public IEnumerable<string> P()
         {
-            var pPrefix = KeySegments.GetNamePPredicate(_name);
+            var pPrefix = KeySegments.GetNamePPredicate(Name);
             var startP = KeyConfig.ConcatBytes(pPrefix, KeyConfig.ByteZero);
             var endP = KeyConfig.ConcatBytes(pPrefix, KeyConfig.ByteOne);
             var predicates = new RocksEnumerable(_db, startP, endP, (it) =>
@@ -308,11 +314,11 @@ namespace Hexastore.Rocks
             if (c == null) {
                 return P(p);
             }
-            var ph = KeySegments.GetNamePKeyPredicate(_name, p);
+            var ph = KeySegments.GetNamePKeyPredicate(Name, p);
             var startS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteOne);
 
-            var (_, pKey, _) = new KeySegments(_name, c).GetKeys();
+            var (_, pKey, _) = new KeySegments(Name, c).GetKeys();
             var continuation = KeyConfig.ConcatBytes(pKey, KeyConfig.ByteOne);
 
             if (KeyConfig.ByteCompare(continuation, startS) < 0) {
@@ -326,7 +332,7 @@ namespace Hexastore.Rocks
 
         public IEnumerable<Triple> PO(string p, TripleObject o)
         {
-            var ph = KeySegments.GetNamePKeyPredicateObject(_name, p, o);
+            var ph = KeySegments.GetNamePKeyPredicateObject(Name, p, o);
             var startS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteOne);
 
@@ -338,11 +344,11 @@ namespace Hexastore.Rocks
             if (c == null) {
                 return PO(p, o);
             }
-            var ph = KeySegments.GetNamePKeyPredicateObject(_name, p, o);
+            var ph = KeySegments.GetNamePKeyPredicateObject(Name, p, o);
             var startS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteOne);
 
-            var (_, pKey, _) = new KeySegments(_name, c).GetKeys();
+            var (_, pKey, _) = new KeySegments(Name, c).GetKeys();
             var continuation = KeyConfig.ConcatBytes(pKey, KeyConfig.ByteOne);
 
             if (KeyConfig.ByteCompare(continuation, startS) < 0) {
@@ -363,7 +369,7 @@ namespace Hexastore.Rocks
         {
             using (var batch = new WriteBatch()) {
                 foreach (var t in triples) {
-                    var (sKey, pKey, oKey) = new KeySegments(_name, t).GetKeys();
+                    var (sKey, pKey, oKey) = new KeySegments(Name, t).GetKeys();
                     batch.Delete(sKey);
                     batch.Delete(pKey);
                     batch.Delete(oKey);
@@ -377,7 +383,7 @@ namespace Hexastore.Rocks
             if (!Exists(s, p, o)) {
                 return false;
             }
-            var (sKey, pKey, oKey) = new KeySegments(_name, s, p, o).GetKeys();
+            var (sKey, pKey, oKey) = new KeySegments(Name, s, p, o).GetKeys();
             using (var batch = new WriteBatch()) {
                 batch.Delete(sKey);
                 batch.Delete(pKey);

--- a/Hexastore.Test/ContinuationTest.cs
+++ b/Hexastore.Test/ContinuationTest.cs
@@ -20,7 +20,7 @@ namespace Hexastore.Test
             foreach (var s in Enumerable.Range(0, 10)) {
                 foreach (var p in Enumerable.Range(0, 10)) {
                     foreach (var o in Enumerable.Range(0, 10)) {
-                        _set.Assert(s.ToString(), p.ToString(), o.ToString());
+                        _set.Assert(s.ToString(), p.ToString(), (o.ToString(), o));
                     }
                 }
             }
@@ -29,59 +29,59 @@ namespace Hexastore.Test
         [TestMethod]
         public void SP_Continuation_Returns()
         {
-            var spc = _set.SP("5", "5", new Triple("5", "5", "1"));
+            var spc = _set.SP("5", "5", new Triple("5", "5", ("1", 1)));
             var next = spc.First();
-            Assert.AreEqual(next, new Triple("5", "5", "2"));
+            Assert.AreEqual(next, new Triple("5", "5", ("2", 2)));
 
-            var sc = _set.S("5", new Triple("5", "2", "3"));
-            Assert.AreEqual(new Triple("5", "2", "4"), sc.First());
+            var sc = _set.S("5", new Triple("5", "2", ("3", 3)));
+            Assert.AreEqual(new Triple("5", "2", ("4", 4)), sc.First());
 
-            Assert.AreEqual(44, _set.S("5", new Triple("5", "5", "5")).ToArray().Count());
-            Assert.AreEqual(4, _set.SP("5", "5", new Triple("5", "5", "5")).ToArray().Count());
+            Assert.AreEqual(44, _set.S("5", new Triple("5", "5", ("5", 5))).ToArray().Count());
+            Assert.AreEqual(4, _set.SP("5", "5", new Triple("5", "5", ("5", 5))).ToArray().Count());
 
-            Assert.ThrowsException<InvalidOperationException>(() => _set.S("5", new Triple("4", "9", "9")));
-            Assert.ThrowsException<InvalidOperationException>(() => _set.S("5", new Triple("4", "9", "9")));
+            Assert.ThrowsException<InvalidOperationException>(() => _set.S("5", new Triple("4", "9", ("9", 9))));
 
-            Assert.AreEqual(0, _set.S("5", new Triple("6", "5", "5")).ToArray().Count());
-            Assert.AreEqual(0, _set.SP("5", "6", new Triple("5", "7", "5")).ToArray().Count());
+            Assert.AreEqual(0, _set.S("5", new Triple("6", "5", ("5", 5))).ToArray().Count());
+            Assert.AreEqual(0, _set.SP("5", "6", new Triple("5", "7", ("5", 5))).ToArray().Count());
         }
 
         [TestMethod]
         public void PO_Continuation_Returns()
         {
-            var poc = _set.PO("4", "4", new Triple("4", "4", "4"));
-            Assert.AreEqual(new Triple("5", "4", "4"), poc.First());
+            var poc = _set.PO("4", "4", new Triple("4", "4", ("4", 4)));
+            var pocFirst = poc.First();
+            Assert.AreEqual(new Triple("5", "4", ("4", 4)), pocFirst);
 
-            var pc = _set.P("4", new Triple("3", "4", "1"));
-            Assert.AreEqual(new Triple("4", "4", "1"), pc.First());
+            var pc = _set.P("4", new Triple("3", "4", ("1", 1)));
+            Assert.AreEqual(new Triple("4", "4", ("1", 1)), pc.First());
 
-            Assert.AreEqual(44, _set.P("5", new Triple("5", "5", "5")).ToArray().Count());
-            Assert.AreEqual(4, _set.PO("5", "5", new Triple("5", "5", "5")).ToArray().Count());
+            Assert.AreEqual(44, _set.P("5", new Triple("5", "5", ("5", 5))).ToArray().Count());
+            Assert.AreEqual(4, _set.PO("5", "5", new Triple("5", "5", ("5", 5))).ToArray().Count());
 
-            Assert.ThrowsException<InvalidOperationException>(() => _set.O("5", new Triple("4", "3", "1")));
-            Assert.ThrowsException<InvalidOperationException>(() => _set.OS("5", "2", new Triple("1", "3", "5")));
+            Assert.ThrowsException<InvalidOperationException>(() => _set.O("5", new Triple("4", "3", ("1", 1))));
+            Assert.ThrowsException<InvalidOperationException>(() => _set.OS("5", "2", new Triple("1", "3", ("5", 5))));
 
-            Assert.AreEqual(0, _set.P("5", new Triple("5", "6", "5")).ToArray().Count());
-            Assert.AreEqual(0, _set.PO("6", "4", new Triple("5", "6", "5")).ToArray().Count());
+            Assert.AreEqual(0, _set.P("5", new Triple("5", "6", ("5", 5))).ToArray().Count());
+            Assert.AreEqual(0, _set.PO("6", "4", new Triple("5", "6", ("5", 5))).ToArray().Count());
         }
 
         [TestMethod]
         public void OS_Continuation_Returns()
         {
-            var osc = _set.OS("4", "4", new Triple("4", "4", "4"));
-            Assert.AreEqual(new Triple("4", "5", "4"), osc.First());
+            var osc = _set.OS("4", "4", new Triple("4", "4", ("4", 4)));
+            Assert.AreEqual(new Triple("4", "5", ("4", 4)), osc.First());
 
-            var oc = _set.O("4", new Triple("3", "4", "4"));
-            Assert.AreEqual(new Triple("3", "5", "4"), oc.First());
+            var oc = _set.O("4", new Triple("3", "4", ("4", 4)));
+            Assert.AreEqual(new Triple("3", "5", ("4", 4)), oc.First());
 
-            Assert.AreEqual(44, _set.O("5", new Triple("5", "5", "5")).ToArray().Count());
-            Assert.AreEqual(4, _set.OS("5", "5", new Triple("5", "5", "5")).ToArray().Count());
+            Assert.AreEqual(44, _set.O("5", new Triple("5", "5", ("5", 5))).ToArray().Count());
+            Assert.AreEqual(4, _set.OS("5", "5", new Triple("5", "5", ("5", 5))).ToArray().Count());
 
-            Assert.ThrowsException<InvalidOperationException>(() => _set.O("5", new Triple("4", "3", "1")));
-            Assert.ThrowsException<InvalidOperationException>(() => _set.OS("1", "3", new Triple("2", "3", "1")));
+            Assert.ThrowsException<InvalidOperationException>(() => _set.O("5", new Triple("4", "3", ("1", 1))));
+            Assert.ThrowsException<InvalidOperationException>(() => _set.OS("1", "3", new Triple("2", "3", ("1", 1))));
 
-            Assert.AreEqual(0, _set.O("5", new Triple("5", "5", "6")).ToArray().Count());
-            Assert.AreEqual(0, _set.OS("6", "4", new Triple("5", "5", "6")).ToArray().Count());
+            Assert.AreEqual(0, _set.O("5", new Triple("5", "5", ("6", 6))).ToArray().Count());
+            Assert.AreEqual(0, _set.OS("6", "4", new Triple("5", "5", ("6", 6))).ToArray().Count());
         }
     }
 }

--- a/Hexastore.Test/ObjectQueryExecutorTest.cs
+++ b/Hexastore.Test/ObjectQueryExecutorTest.cs
@@ -85,7 +85,7 @@ namespace Hexastore.Test
 
             var rsp = new ObjectQueryExecutor().Query(query, (RocksGraph)set);
             var values = rsp.Values.ToArray();
-            var testTriple = new Triple("300", "age", TripleObject.FromData(30));
+            var testTriple = new Triple("300", "age", (new JValue(30), -1));
 
             CollectionAssert.Contains(values, testTriple);
             Assert.AreEqual(1, values.Count());
@@ -124,7 +124,7 @@ namespace Hexastore.Test
 
             var rsp = new ObjectQueryExecutor().Query(query, (RocksGraph)set);
             var values = rsp.Values.ToArray();
-            var testTriple = new Triple("500", "name", TripleObject.FromData("name500"));
+            var testTriple = new Triple("500", "name", (new JValue("name500"), -1));
             CollectionAssert.Contains(values, testTriple);
             Assert.AreEqual(1, rsp.Values.Count());
             Assert.AreEqual(null, rsp.Continuation);
@@ -147,7 +147,7 @@ namespace Hexastore.Test
 
             var rsp = new ObjectQueryExecutor().Query(query, (RocksGraph)set);
             var values = rsp.Values.ToArray();
-            var testTriple = new Triple("500", "name", TripleObject.FromData("name500"));
+            var testTriple = new Triple("500", "name", (new JValue("name500"), -1));
             CollectionAssert.Contains(values, testTriple);
             Assert.AreEqual(1, rsp.Values.Count());
             Assert.AreEqual(null, rsp.Continuation);
@@ -169,8 +169,8 @@ namespace Hexastore.Test
 
             var rsp = new ObjectQueryExecutor().Query(query, (RocksGraph)set);
             var values = rsp.Values.ToArray();
-            var testTriple1 = new Triple("300", "age", TripleObject.FromData(30));
-            var testTriple2 = new Triple("700", "age", TripleObject.FromData(30));
+            var testTriple1 = new Triple("300", "age", (new JValue(30), -1));
+            var testTriple2 = new Triple("700", "age", (new JValue(30), -1));
             CollectionAssert.Contains(values, testTriple1);
             CollectionAssert.Contains(values, testTriple2);
             Assert.AreEqual(2, rsp.Values.Count());
@@ -194,8 +194,8 @@ namespace Hexastore.Test
 
             var rsp = new ObjectQueryExecutor().Query(query, (RocksGraph)set);
             var values = rsp.Values.ToArray();
-            var testTriple1 = new Triple("300", "name", TripleObject.FromData("name300"));
-            var testTriple2 = new Triple("700", "name", TripleObject.FromData("name700"));
+            var testTriple1 = new Triple("300", "name", (new JValue("name300"), -1));
+            var testTriple2 = new Triple("700", "name", (new JValue("name700"), -1));
             CollectionAssert.Contains(values, testTriple1);
             CollectionAssert.Contains(values, testTriple2);
             Assert.AreEqual(2, rsp.Values.Count());
@@ -219,8 +219,8 @@ namespace Hexastore.Test
 
             var rsp = new ObjectQueryExecutor().Query(query, (RocksGraph)set);
             var values = rsp.Values.ToArray();
-            var testTriple1 = new Triple("100", "name", TripleObject.FromData("name100"));
-            var testTriple2 = new Triple("500", "name", TripleObject.FromData("name500"));
+            var testTriple1 = new Triple("100", "name", (new JValue("name100"), -1));
+            var testTriple2 = new Triple("500", "name", (new JValue("name500"), -1));
             CollectionAssert.Contains(values, testTriple1);
             CollectionAssert.Contains(values, testTriple2);
             Assert.AreEqual(2, rsp.Values.Count());

--- a/Hexastore.Test/StoreProcessorTest.cs
+++ b/Hexastore.Test/StoreProcessorTest.cs
@@ -140,18 +140,20 @@ namespace Hexastore.Test
                 name = (string)null,
                 contains = new
                 {
+                    id = "200",
                     name = "name202",
                     values = new object[] {
                         new
                         {
+                            id = "300",
                             name = "name303",
                             age = (int?)null,
-                        }
+                        },
                     }
                 }
             };
-            StoreProcessor.PatchJson("app2", JObject.FromObject(patch));
 
+            StoreProcessor.PatchJson("app2", JObject.FromObject(patch));
             var rsp = StoreProcessor.GetSubject("app2", "100", null, 3);
             var expected = new
             {
@@ -159,12 +161,17 @@ namespace Hexastore.Test
                 age = 20,
                 contains = new
                 {
-                    id = "100#contains",
+                    id = "200",
                     name = "name202",
-                    values = new
-                    {
-                        id = "100#contains#values#0",
-                        name = "name303"
+                    values = new object[] {
+                        new {
+                            id = "300",
+                            name = "name303"
+                        },
+                        new {
+                            id = "400",
+                            name = "name400"
+                        }
                     }
                 }
             };

--- a/Hexastore.Test/TripleConverterTest.cs
+++ b/Hexastore.Test/TripleConverterTest.cs
@@ -87,7 +87,7 @@ namespace Hexastore.Test
             expected.Add(new Triple("100#contains", "name", TripleObject.FromData("name200")));
             expected.Add(new Triple("100#contains", "values", "100#contains#values#0"));
             expected.Add(new Triple("100#contains#values#0", "age", TripleObject.FromData(null)));
-            CollectionAssert.AreEquivalent(expected.ToArray(), graph.ToArray());
+            CollectionAssert.AreEqual(expected, graph.ToArray(), new UnorderedTripleComparer());
         }
     }
 }

--- a/Hexastore.Test/TripleTest.cs
+++ b/Hexastore.Test/TripleTest.cs
@@ -82,8 +82,8 @@ namespace Hexastore.Test
             _set.Assert("s2", "b2", "c2"); // duplicate assert
             _set.Assert("s2", "b3", "c3");
 
-            _set.Assert("s1", "b2", "c21");
-            _set.Assert("s1", "b2", "c22");
+            _set.Assert("s1", "b2", ("c21", 0));
+            _set.Assert("s1", "b2", ("c22", 1));
             _set.Assert("s1", "b3", TripleObject.FromData("c3"));
             _set.Assert("s1", "b1", "c1");
 
@@ -91,8 +91,8 @@ namespace Hexastore.Test
 
             var byS1B2 = _set.SP("s1", "b2").ToArray();
             Assert.AreEqual(byS1B2.Count(), 2);
-            CollectionAssert.Contains(byS1B2, new Triple("s1", "b2", "c21"));
-            CollectionAssert.Contains(byS1B2, new Triple("s1", "b2", "c22"));
+            CollectionAssert.Contains(byS1B2, new Triple("s1", "b2", ("c21", 0)));
+            CollectionAssert.Contains(byS1B2, new Triple("s1", "b2", ("c22", 1)));
 
             var byS1B3 = _set.SP("s1", "b3").ToArray();
             Assert.AreEqual(byS1B3.Count(), 1);

--- a/Hexastore/Graph/ISPIGraph.cs
+++ b/Hexastore/Graph/ISPIGraph.cs
@@ -4,7 +4,8 @@ using System.Text;
 
 namespace Hexastore.Graph
 {
-    public interface IStoreGraph : IGraph, IPagableGraph, ISPIndexQueryableGraph
+    public interface ISPIndexQueryableGraph
     {
+        Triple SPI(string s, string p, int index);
     }
 }

--- a/Hexastore/Graph/MemoryGraph.cs
+++ b/Hexastore/Graph/MemoryGraph.cs
@@ -363,6 +363,11 @@ namespace Hexastore.Graph
             Assert(assert);
         }
 
+        public Triple SPI(string s, string p, int index)
+        {
+            throw new System.NotImplementedException();
+        }
+
         private class SubjectGrouping : IGrouping<string, IGrouping<string, TripleObject>>
         {
             private KeyValuePair<string, IDictionary<string, ISet<TripleObject>>> _kv;

--- a/Hexastore/Graph/SPOIndex.cs
+++ b/Hexastore/Graph/SPOIndex.cs
@@ -81,7 +81,10 @@ namespace Hexastore.Graph
                 z = new List<TZ>();
                 yz[ty] = z;
             }
-            z.Add(tz);
+            if (!z.Contains(tz)) {
+                // todo: keyed collection / ordered hashset
+                z.Add(tz);
+            }
         }
         public IEnumerable<IGrouping<string, TripleObject>> GetSubjectGroupings(string s)
         {

--- a/Hexastore/Graph/TripleObject.cs
+++ b/Hexastore/Graph/TripleObject.cs
@@ -58,9 +58,19 @@ namespace Hexastore.Graph
             return new TripleObject((JValue)jToken, false, null);
         }
 
+        public static implicit operator TripleObject(ValueTuple<JToken, int> jToken)
+        {
+            return new TripleObject((JValue)jToken.Item1, false, jToken.Item2);
+        }
+
         public static implicit operator TripleObject(string id)
         {
             return new TripleObject(id, true, JTokenType.String, null);
+        }
+
+        public static implicit operator TripleObject(ValueTuple<string, int> id)
+        {
+            return new TripleObject(id.Item1, true, JTokenType.String, id.Item2);
         }
 
         public static TripleObject FromId(string s)
@@ -71,6 +81,11 @@ namespace Hexastore.Graph
         public static TripleObject FromData(string s)
         {
             return new TripleObject(s, false, JTokenType.String, null);
+        }
+
+        public static TripleObject FromData(string s, int index)
+        {
+            return new TripleObject(s, false, JTokenType.String, index);
         }
 
         public static TripleObject FromData(int n)
@@ -112,9 +127,9 @@ namespace Hexastore.Graph
         public override string ToString()
         {
             if (IsID) {
-                return $"<{Value}>";
+                return $"<{Value}> c:{Index}";
             } else {
-                return Value;
+                return $"{Value} c:{Index}";
             }
         }
 


### PR DESCRIPTION
The SPciO key is split into SPci (key) and iO (value).
This allows for deterministically calculating the triples
that are to be removed from a graph in a PATCH
operation. By knowing the key of the triples that
are to be removed, a scan is avoided.

Keys are stored as follows. Breaking change

name.S subject predicate index
name.P predicate isId object index subject
name.O isId object subject predicate index