### PR TITLE
Add patitionId in update requests

### DIFF
--- a/Hexastore.Web/Controllers/StoreController.cs
+++ b/Hexastore.Web/Controllers/StoreController.cs
@@ -81,10 +81,10 @@ namespace Hexastore.Web.Controllers
         }
 
         [HttpPost("{storeId}/ingest")]
-        public async Task<IActionResult> Ingest(string storeId, [FromBody]JObject body)
+        public async Task<IActionResult> Ingest(string storeId, [FromBody]UpdateRequest req)
         {
-            _logger.LogInformation(LoggingEvents.ControllerIngest, "INGEST: store {store}", storeId);
-            string url = body["url"]?.ToString();
+            _logger.LogInformation(LoggingEvents.ControllerIngest, "INGEST: store: {store} partition: {partitionId}", storeId, req.PartitionId);
+            string url = req.Data?["url"]?.ToString();
             if (string.IsNullOrEmpty(url)) {
                 return BadRequest();
             }
@@ -104,7 +104,8 @@ namespace Hexastore.Web.Controllers
                             {
                                 Operation = EventType.POST,
                                 Strict = true,
-                                Data = batch.ToString(Formatting.None)
+                                Data = batch.ToString(Formatting.None),
+                                PartitionId = req.PartitionId
                             };
                             await SendEvent(storeId, e);
                             _logger.LogInformation("Batch ingestion", batch.Count);
@@ -131,16 +132,17 @@ namespace Hexastore.Web.Controllers
         }
 
         [HttpPost("{storeId}")]
-        public async Task<IActionResult> Post(string storeId, [FromBody]JToken data)
+        public async Task<IActionResult> Post(string storeId, [FromBody]UpdateRequest req)
         {
-            _logger.LogInformation(LoggingEvents.ControllerPost, "POST: store {store}", storeId);
+            _logger.LogInformation(LoggingEvents.ControllerPost, "POST: store: {store} partition: {partitionId}", storeId, req.PartitionId);
             try {
                 var (_, _, _, strict) = GetParams();
                 var e = new StoreEvent
                 {
                     Operation = EventType.POST,
                     Strict = strict,
-                    Data = data.ToString(Formatting.None)
+                    Data = req.Data.ToString(Formatting.None),
+                    PartitionId = req.PartitionId
                 };
                 await SendEvent(storeId, e);
                 return Accepted();
@@ -150,14 +152,15 @@ namespace Hexastore.Web.Controllers
         }
 
         [HttpPatch("{storeId}/json")]
-        public async Task<IActionResult> PatchJson(string storeId, [FromBody]JToken data)
+        public async Task<IActionResult> PatchJson(string storeId, [FromBody]UpdateRequest req)
         {
-            _logger.LogInformation(LoggingEvents.ControllerPatchJson, "PATCH JSON: store {storeId}", storeId);
+            _logger.LogInformation(LoggingEvents.ControllerPatchJson, "PATCH JSON: store: {storeId} partition: {partitionId}", storeId, req.PartitionId);
             try {
                 var e = new StoreEvent
                 {
                     Operation = EventType.PATCH_JSON,
-                    Data = data.ToString(Formatting.None)
+                    Data = req.Data.ToString(Formatting.None),
+                    PartitionId = req.PartitionId
                 };
                 await SendEvent(storeId, e);
                 return Accepted();
@@ -167,14 +170,15 @@ namespace Hexastore.Web.Controllers
         }
 
         [HttpPatch("{storeId}/triple")]
-        public async Task<IActionResult> PatchTriple(string storeId, [FromBody]JObject data)
+        public async Task<IActionResult> PatchTriple(string storeId, [FromBody]UpdateRequest req)
         {
-            _logger.LogInformation(LoggingEvents.ControllerPatchTriple, "PATCH TRIPLE: store {store}", storeId);
+            _logger.LogInformation(LoggingEvents.ControllerPatchTriple, "PATCH TRIPLE: store: {store} partition: {partitionId}", storeId, req.PartitionId);
             try {
                 var e = new StoreEvent
                 {
                     Operation = EventType.PATCH_TRIPLE,
-                    Data = data.ToString(Formatting.None)
+                    Data = req.Data.ToString(Formatting.None),
+                    PartitionId = req.PartitionId
                 };
                 await SendEvent(storeId, e);
                 return Accepted();
@@ -184,14 +188,15 @@ namespace Hexastore.Web.Controllers
         }
 
         [HttpDelete("{storeId}/subject")]
-        public async Task<IActionResult> Delete(string storeId, [FromBody]JObject data)
+        public async Task<IActionResult> Delete(string storeId, [FromBody]UpdateRequest req)
         {
-            _logger.LogInformation(LoggingEvents.ControllerDelete, "DELETE: store {store}", storeId);
+            _logger.LogInformation(LoggingEvents.ControllerDelete, "DELETE: store: {store} parition: {partitionId}", storeId, req.PartitionId);
             try {
                 var e = new StoreEvent
                 {
                     Operation = EventType.DELETE,
-                    Data = data.ToString(Formatting.None)
+                    Data = req.Data.ToString(Formatting.None),
+                    PartitionId = req.PartitionId
                 };
                 await SendEvent(storeId, e);
                 return Accepted();

--- a/Hexastore.Web/Controllers/UpdateRequest.cs
+++ b/Hexastore.Web/Controllers/UpdateRequest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Hexastore.Web.Controllers
+{
+    public class UpdateRequest
+    {
+        [JsonProperty("partitionId")]
+        public string PartitionId { get; set; }
+
+        [JsonProperty("data")]
+        public JToken Data { get; set; }
+    }
+}

--- a/Hexastore.Web/EventHubs/EventSender.cs
+++ b/Hexastore.Web/EventHubs/EventSender.cs
@@ -20,12 +20,10 @@ namespace Hexastore.Web.EventHubs
 
         public int MaxBatchSize
         {
-            get
-            {
+            get {
                 return 1000;
             }
-            set
-            {
+            set {
             }
         }
 
@@ -50,10 +48,15 @@ namespace Hexastore.Web.EventHubs
             }
 
             try {
-                storeEvent.PartitionId = storeEvent.StoreId.GetHashCode() % _storeConfig.EventHubPartitionCount;
+                int ehPartitionId;
+                if (!string.IsNullOrEmpty(storeEvent.PartitionId)) {
+                    ehPartitionId = storeEvent.PartitionId.GetHashCode() % _storeConfig.EventHubPartitionCount;
+                } else {
+                    ehPartitionId = storeEvent.StoreId.GetHashCode() % _storeConfig.EventHubPartitionCount;
+                }
                 var content = JsonConvert.SerializeObject(storeEvent, Formatting.None);
                 var bytes = Encoding.UTF8.GetBytes(content);
-                await _eventHubClient.SendAsync(new EventData(bytes), storeEvent.PartitionId.ToString());
+                await _eventHubClient.SendAsync(new EventData(bytes), ehPartitionId.ToString());
             } catch (Exception e) {
                 Console.WriteLine(e);
             }

--- a/Hexastore.Web/EventHubs/EventSender.cs
+++ b/Hexastore.Web/EventHubs/EventSender.cs
@@ -36,6 +36,7 @@ namespace Hexastore.Web.EventHubs
                 _eventHubClient = EventHubClient.CreateFromConnectionString(_storeConfig.EventHubConnectionString);
                 _ = this.StartListeners();
                 _ = _storeReceiver.LogCount();
+                _active = true;
             }
         }
 

--- a/Hexastore.Web/EventHubs/StoreEvent.cs
+++ b/Hexastore.Web/EventHubs/StoreEvent.cs
@@ -24,7 +24,7 @@ namespace Hexastore.Web.EventHubs
         public bool Strict { get; set; }
 
         [JsonProperty("partitionId")]
-        public int PartitionId { get; set; }
+        public string PartitionId { get; set; }
 
         [JsonProperty("storeId")]
         public string StoreId { get; set; }


### PR DESCRIPTION
- Routes the request to a hashed event hub partition
- Allows clients to specify the ordering requirement
- If none is provided then storeId is used