### PR TITLE
Reduce data duplication in rocks keys

### DIFF
--- a/Hexastore.Rocks/KeyConfig.cs
+++ b/Hexastore.Rocks/KeyConfig.cs
@@ -13,6 +13,7 @@ namespace Hexastore.Rocks
         public byte[] O { get; private set; }
         public byte[] IsId { get; private set; }
         public byte[] Index { get; private set; }
+        public byte[] Type { get; private set; }
 
         private byte[] _sKey;
         private byte[] _pKey;
@@ -28,6 +29,8 @@ namespace Hexastore.Rocks
             O = KeyConfig.GetBytes(o.ToValue());
             IsId = o.IsID ? KeyConfig.ByteTrue : KeyConfig.ByteFalse;
             Index = BitConverter.GetBytes(o.Index);
+            var oTyped = o.ToTypedJSON();
+            Type = BitConverter.GetBytes((ushort)oTyped.Type);
         }
 
         public KeySegments(string name, Triple t) : this(name, t.Subject, t.Predicate, t.Object)

--- a/Hexastore.Rocks/RocksEnumerable.cs
+++ b/Hexastore.Rocks/RocksEnumerable.cs
@@ -12,25 +12,23 @@ namespace Hexastore.Rocks
         private readonly byte[] _start;
         private readonly byte[] _end;
         private readonly Func<Iterator, Iterator> _nextFunction;
-        private readonly Func<Iterator, Triple> _currentTripleFunction;
 
-        public RocksEnumerable(RocksDb db, byte[] start, byte[] end, Func<Iterator, Iterator> nextFunction, Func<Iterator, Triple> currentTripleFunction)
+        public RocksEnumerable(RocksDb db, byte[] start, byte[] end, Func<Iterator, Iterator> nextFunction)
         {
             _db = db;
             _start = start;
             _end = end;
             _nextFunction = nextFunction;
-            _currentTripleFunction = currentTripleFunction;
         }
 
         public IEnumerator GetEnumerator()
         {
-            return new RocksEnumerator(_db, _start, _end, _nextFunction, _currentTripleFunction);
+            return new RocksEnumerator(_db, _start, _end, _nextFunction);
         }
 
         IEnumerator<Triple> IEnumerable<Triple>.GetEnumerator()
         {
-            return new RocksEnumerator(_db, _start, _end, _nextFunction, _currentTripleFunction);
+            return new RocksEnumerator(_db, _start, _end, _nextFunction);
         }
     }
 
@@ -41,24 +39,22 @@ namespace Hexastore.Rocks
         private readonly byte[] _end;
         private byte[] _currentKey;
         private readonly Func<Iterator, Iterator> _nextFunction;
-        private readonly Func<Iterator, Triple> _currentTripleFunction;
         private Iterator _iterator;
 
-        public RocksEnumerator(RocksDb db, byte[] start, byte[] end, Func<Iterator, Iterator> nextFunction, Func<Iterator, Triple> currentTripleFunction)
+        public RocksEnumerator(RocksDb db, byte[] start, byte[] end, Func<Iterator, Iterator> nextFunction)
         {
             _db = db;
             _start = start;
             _end = end;
             _currentKey = null;
             _nextFunction = nextFunction;
-            _currentTripleFunction = currentTripleFunction;
         }
 
         public Triple Current
         {
             get
             {
-                return _currentTripleFunction(_iterator);
+                return _iterator.IteratorToTriple();
             }
         }
 

--- a/Hexastore.Rocks/RocksEnumerable.cs
+++ b/Hexastore.Rocks/RocksEnumerable.cs
@@ -12,23 +12,25 @@ namespace Hexastore.Rocks
         private readonly byte[] _start;
         private readonly byte[] _end;
         private readonly Func<Iterator, Iterator> _nextFunction;
+        private readonly Func<Iterator, Triple> _currentTripleFunction;
 
-        public RocksEnumerable(RocksDb db, byte[] start, byte[] end, Func<Iterator, Iterator> nextFunction)
+        public RocksEnumerable(RocksDb db, byte[] start, byte[] end, Func<Iterator, Iterator> nextFunction, Func<Iterator, Triple> currentTripleFunction)
         {
             _db = db;
             _start = start;
             _end = end;
             _nextFunction = nextFunction;
+            _currentTripleFunction = currentTripleFunction;
         }
 
         public IEnumerator GetEnumerator()
         {
-            return new RocksEnumerator(_db, _start, _end, _nextFunction);
+            return new RocksEnumerator(_db, _start, _end, _nextFunction, _currentTripleFunction);
         }
 
         IEnumerator<Triple> IEnumerable<Triple>.GetEnumerator()
         {
-            return new RocksEnumerator(_db, _start, _end, _nextFunction);
+            return new RocksEnumerator(_db, _start, _end, _nextFunction, _currentTripleFunction);
         }
     }
 
@@ -39,22 +41,24 @@ namespace Hexastore.Rocks
         private readonly byte[] _end;
         private byte[] _currentKey;
         private readonly Func<Iterator, Iterator> _nextFunction;
+        private readonly Func<Iterator, Triple> _currentTripleFunction;
         private Iterator _iterator;
 
-        public RocksEnumerator(RocksDb db, byte[] start, byte[] end, Func<Iterator, Iterator> nextFunction)
+        public RocksEnumerator(RocksDb db, byte[] start, byte[] end, Func<Iterator, Iterator> nextFunction, Func<Iterator, Triple> currentTripleFunction)
         {
             _db = db;
             _start = start;
             _end = end;
             _currentKey = null;
             _nextFunction = nextFunction;
+            _currentTripleFunction = currentTripleFunction;
         }
 
         public Triple Current
         {
             get
             {
-                return _iterator.Value().ToTriple();
+                return _currentTripleFunction(_iterator);
             }
         }
 

--- a/Hexastore.Rocks/RocksGraph.cs
+++ b/Hexastore.Rocks/RocksGraph.cs
@@ -118,7 +118,7 @@ namespace Hexastore.Rocks
             var oPrefix = keySegments.GetOPrefix();
             var start = KeyConfig.ConcatBytes(oPrefix, KeyConfig.ByteZero);
             var end = KeyConfig.ConcatBytes(oPrefix, KeyConfig.ByteOne);
-            var oEnumerable = new RocksEnumerable(_db, start, end, (it) => it.Next(), (it) => { return it.IteratorToTriple(); });
+            var oEnumerable = new RocksEnumerable(_db, start, end, (it) => it.Next());
             return oEnumerable.Any(x => x.Predicate == p);
         }
 
@@ -133,8 +133,7 @@ namespace Hexastore.Rocks
                 var splits = KeyConfig.Split(key);
                 var nextKey = KeyConfig.ConcatBytes(splits[0], KeyConfig.ByteZero, splits[1], KeyConfig.ByteOne);
                 return it.Seek(nextKey);
-            },
-            (it) => { return it.IteratorToTriple(); }).Select(x => x.Subject);
+            }).Select(x => x.Subject);
 
             foreach (var s in subjects) {
                 var sh = KeySegments.GetNameSKeySubject(Name, s);
@@ -158,7 +157,7 @@ namespace Hexastore.Rocks
             var nameBytes = KeySegments.GetNameSKey(Name);
             var start = KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteZero);
             var end = KeyConfig.ConcatBytes(nameBytes, KeyConfig.ByteOne);
-            return new RocksEnumerable(_db, start, end, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, start, end, (Iterator it) => { return it.Next(); });
         }
 
         public IGraph Merge(IGraph g)
@@ -180,7 +179,7 @@ namespace Hexastore.Rocks
             var sh = KeySegments.GetNameSKeySubject(Name, s);
             var startS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteOne);
-            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> S(string s, Triple c)
@@ -200,7 +199,7 @@ namespace Hexastore.Rocks
                 return Enumerable.Empty<Triple>();
             }
 
-            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> SP(string s, string p)
@@ -208,7 +207,7 @@ namespace Hexastore.Rocks
             var sh = KeySegments.GetNameSKeySubjectPredicate(Name, s, p);
             var startS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(sh, KeyConfig.ByteOne);
-            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
         }
 
         public Triple SPI(string s, string p, int index)
@@ -237,7 +236,7 @@ namespace Hexastore.Rocks
                 return Enumerable.Empty<Triple>();
             }
 
-            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> O(TripleObject o)
@@ -246,7 +245,7 @@ namespace Hexastore.Rocks
             var startS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteOne);
 
-            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> O(TripleObject o, Triple c)
@@ -268,7 +267,7 @@ namespace Hexastore.Rocks
                 return Enumerable.Empty<Triple>();
             }
 
-            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> OS(TripleObject o, string s)
@@ -277,7 +276,7 @@ namespace Hexastore.Rocks
             var startS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(oh, KeyConfig.ByteOne);
 
-            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> OS(TripleObject o, string s, Triple c)
@@ -297,7 +296,7 @@ namespace Hexastore.Rocks
             } else if (KeyConfig.ByteCompare(continuation, endS) > 0) {
                 return Enumerable.Empty<Triple>();
             }
-            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> P(string p)
@@ -306,7 +305,7 @@ namespace Hexastore.Rocks
             var startS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteOne);
 
-            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<string> P()
@@ -320,8 +319,7 @@ namespace Hexastore.Rocks
                 var splits = KeyConfig.Split(key);
                 var nextKey = KeyConfig.ConcatBytes(splits[0], KeyConfig.ByteZero, splits[1], KeyConfig.ByteOne);
                 return it.Seek(nextKey);
-            },
-            (it) => { return it.IteratorToTriple(); }).Select(x => x.Predicate);
+            }).Select(x => x.Predicate);
 
             return predicates;
         }
@@ -344,7 +342,7 @@ namespace Hexastore.Rocks
                 return Enumerable.Empty<Triple>();
             }
 
-            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> PO(string p, TripleObject o)
@@ -353,7 +351,7 @@ namespace Hexastore.Rocks
             var startS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteZero);
             var endS = KeyConfig.ConcatBytes(ph, KeyConfig.ByteOne);
 
-            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, startS, endS, (Iterator it) => { return it.Next(); });
         }
 
         public IEnumerable<Triple> PO(string p, TripleObject o, Triple c)
@@ -374,7 +372,7 @@ namespace Hexastore.Rocks
                 return Enumerable.Empty<Triple>();
             }
 
-            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); }, (it) => { return it.IteratorToTriple(); });
+            return new RocksEnumerable(_db, continuation, endS, (Iterator it) => { return it.Next(); });
         }
 
         public bool Retract(Triple t)

--- a/Hexastore.Rocks/RocksPredicateGrouping.cs
+++ b/Hexastore.Rocks/RocksPredicateGrouping.cs
@@ -35,7 +35,7 @@ namespace Hexastore.Rocks
             IEnumerable<Triple> idEnum = new RocksEnumerable(_db, start, end, (iterator) =>
             {
                 return iterator.Next();
-            }, (iterator) => { return iterator.IteratorToTriple(); });
+            });
 
             foreach (var item in idEnum) {
                 yield return item.Object;

--- a/Hexastore.Rocks/RocksPredicateGrouping.cs
+++ b/Hexastore.Rocks/RocksPredicateGrouping.cs
@@ -35,7 +35,7 @@ namespace Hexastore.Rocks
             IEnumerable<Triple> idEnum = new RocksEnumerable(_db, start, end, (iterator) =>
             {
                 return iterator.Next();
-            });
+            }, (iterator) => { return iterator.IteratorToTriple(); });
 
             foreach (var item in idEnum) {
                 yield return item.Object;

--- a/Hexastore.Rocks/RocksSubjectGrouping.cs
+++ b/Hexastore.Rocks/RocksSubjectGrouping.cs
@@ -40,8 +40,7 @@ namespace Hexastore.Rocks
                 var splits = KeyConfig.Split(key);
                 var nextKey = KeyConfig.ConcatBytes(splits[0], KeyConfig.ByteZero, splits[1], KeyConfig.ByteZero, splits[2], KeyConfig.ByteOne);
                 return it.Seek(nextKey);
-            },
-            (it) => { return it.IteratorToTriple(); }).Select(x => x.Predicate);
+            }).Select(x => x.Predicate);
 
             foreach (var p in predicates) {
                 yield return new RocksPredicateGrouping(_db, _name, _s, p);

--- a/Hexastore.Rocks/RocksSubjectGrouping.cs
+++ b/Hexastore.Rocks/RocksSubjectGrouping.cs
@@ -40,7 +40,8 @@ namespace Hexastore.Rocks
                 var splits = KeyConfig.Split(key);
                 var nextKey = KeyConfig.ConcatBytes(splits[0], KeyConfig.ByteZero, splits[1], KeyConfig.ByteZero, splits[2], KeyConfig.ByteOne);
                 return it.Seek(nextKey);
-            }).Select(x => x.Predicate);
+            },
+            (it) => { return it.IteratorToTriple(); }).Select(x => x.Predicate);
 
             foreach (var p in predicates) {
                 yield return new RocksPredicateGrouping(_db, _name, _s, p);

--- a/Hexastore.Rocks/TripleExtensions.cs
+++ b/Hexastore.Rocks/TripleExtensions.cs
@@ -9,7 +9,7 @@ namespace Hexastore.Rocks
 {
     public static class TripleExtensions
     {
-        private static int BYTES_PER_INT = 4;
+        private const int BYTES_PER_INT = 4;
 
         public static byte[] GetOIsIdTypeBytes(this Triple triple)
         {

--- a/Hexastore.Rocks/TripleExtensions.cs
+++ b/Hexastore.Rocks/TripleExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Hexastore.Graph;
 using Newtonsoft.Json.Linq;
+using RocksDbSharp;
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -8,28 +9,26 @@ namespace Hexastore.Rocks
 {
     public static class TripleExtensions
     {
-        public static byte[] ToBytes(this Triple triple)
+        private static int BYTES_PER_INT = 4;
+
+        public static byte[] GetOIsIdTypeBytes(this Triple triple)
         {
-            var s = triple.Subject;
-            var p = triple.Predicate;
             var o = triple.Object;
-            var sBytes = GetBytes(s);
-            var pBytes = GetBytes(p);
             var oTyped = o.ToTypedJSON();
             var oTypeBytes = BitConverter.GetBytes((ushort)oTyped.Type);
             var oBytes = GetBytes(o.ToValue());
             var idBytes = o.IsID ? new byte[] { 1 } : new byte[] { 0 };
-            var indexBytes = BitConverter.GetBytes(o.Index);
 
-            var totalLength = (4 * 6) + sBytes.Length + pBytes.Length + oBytes.Length + idBytes.Length + oTypeBytes.Length + indexBytes.Length;
+            var totalLength = (BYTES_PER_INT * 3) + oBytes.Length + idBytes.Length + oTypeBytes.Length;
             var destination = new byte[totalLength];
-            var spio = new[] { sBytes, pBytes, indexBytes, idBytes, oTypeBytes, oBytes };
+            var oIdType = new[] { oBytes, idBytes, oTypeBytes };
 
             var index = 0;
-            foreach (var item in spio) {
+            foreach (var item in oIdType)
+            {
                 var lenBytes = BitConverter.GetBytes(item.Length);
-                Buffer.BlockCopy(lenBytes, 0, destination, index, 4);
-                index += 4;
+                Buffer.BlockCopy(lenBytes, 0, destination, index, BYTES_PER_INT);
+                index += BYTES_PER_INT;
                 Buffer.BlockCopy(item, 0, destination, index, item.Length);
                 index += item.Length;
             }
@@ -37,58 +36,280 @@ namespace Hexastore.Rocks
             return destination;
         }
 
-        public static Triple ToTriple(this byte[] spoBytes)
+        public static Triple ToTriple(this byte[] spoKey, byte[] spoValue)
         {
-            var index = 0;
-            var (s, slen) = ReadString(spoBytes, index);
-            index += 4 + slen;
-            var (p, pLen) = ReadString(spoBytes, index);
-            index += 4 + pLen;
-            var (arrayIndex, arrayIndexLength) = ReadInt(spoBytes, index);
-            index += 4 + arrayIndexLength;
-            var (id, idLen) = ReadBool(spoBytes, index);
-            index += 4 + idLen;
-            var (type, typeLength) = ReadUInt16(spoBytes, index);
-            index += 4 + typeLength;
-            var (ovalue, _) = ReadString(spoBytes, index);
+            return SKVPToTriple(spoKey, spoValue);
+        }
 
-            return new Triple(s, p, new TripleObject(ovalue, id, (JTokenType)type, arrayIndex));
+        public static Triple IteratorToTriple(this Iterator iterator)
+        {
+            var key = iterator.Key();
+            var splits = KeyConfig.Split(key);
+            var keySpan = new ReadOnlySpan<byte>(splits[0], splits[0].Length - 2, 2);
+            if(keySpan.SequenceEqual(new ReadOnlySpan<byte>(KeyConfig.ByteS)))
+            {
+                return SKVPToTriple(iterator.Key(), iterator.Value());
+            }
+            else if (keySpan.SequenceEqual(new ReadOnlySpan<byte>(KeyConfig.ByteP)))
+            {
+                return PKVPToTriple(iterator.Key(), iterator.Value());
+            }
+            else
+            {
+                return OKVPToTriple(iterator.Key(), iterator.Value());
+            }
+        }
+
+        private static Triple OKVPToTriple(byte[] key, byte[] value)
+        {
+            // name .O z isId z O z S z P z Index
+            // NAME: 
+            ReadOnlySpan<byte> isId, index, tokenType;
+            int oStart = 0, oLength = 0, sStart = 0, sLength = 0, pStart = 0, pLength = 0; 
+            var dotOSpan = new ReadOnlySpan<byte>(KeyConfig.ByteO);
+            var currentIndex = 0;
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (dotOSpan.SequenceEqual(new ReadOnlySpan<byte>(key, i, 2)))
+                {
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            // IsId:
+            // currentIdex is at '.' in '.O'. Next should be 'z', can skip both 'Oz' to get to isId 
+            currentIndex += 3;
+            isId = new ReadOnlySpan<byte>(key, currentIndex, 1);
+            // currentIdex is at 'IsId'. Next should be 'z', can skip both 'IsId z' to get to o value 
+            currentIndex += 2;
+
+            // O:
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (key[i] == 0)
+                {
+                    oStart = currentIndex;
+                    oLength = i - currentIndex;
+                    currentIndex = i;
+                    break;
+                }
+            }
+            currentIndex++;
+
+            // S:
+            for(var i = currentIndex; i < key.Length; i++)
+            {
+                if (key[i] == 0)
+                {
+                    sStart = currentIndex;
+                    sLength = i - currentIndex;
+                    currentIndex = i;
+                    break;
+                }
+            }
+            currentIndex++;
+
+            // P:
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (key[i] == 0)
+                {
+                    pStart = currentIndex;
+                    pLength = i - currentIndex;
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            // Index:
+            // currentIdex is at 'z'. Next should be Index 
+            currentIndex++;
+            index = new ReadOnlySpan<byte>(key, currentIndex, key.Length - currentIndex);
+            // TokenType:
+            tokenType = new ReadOnlySpan<byte>(value);
+
+            return new Triple(Encoding.UTF8.GetString(key, sStart, sLength), Encoding.UTF8.GetString(key, pStart, pLength), new TripleObject(Encoding.UTF8.GetString(key, oStart, oLength), MemoryMarshal.Read<bool>(isId), (JTokenType)MemoryMarshal.Read<ushort>(tokenType), MemoryMarshal.Read<int>(index)));
+        }
+
+        private static Triple PKVPToTriple(byte[] key, byte[] value)
+        {
+            // name .P z p z isId z O z Index z S 
+            // NAME: 
+            ReadOnlySpan<byte> isId, index, tokenType;
+            int oStart = 0, oLength = 0, sStart = 0, sLength = 0, pStart = 0, pLength = 0;
+
+            var dotPSpan = new ReadOnlySpan<byte>(KeyConfig.ByteP);
+            var currentIndex = 0;
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (dotPSpan.SequenceEqual(new ReadOnlySpan<byte>(key, i, 2)))
+                {
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            // P:
+            // currentIndex is at '.' in '.P'. Next should be 'z', can skip both 'Pz' to get to p value
+            currentIndex += 3;
+
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (key[i] == 0)
+                {
+                    pStart = currentIndex;
+                    pLength = i - currentIndex;
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+
+            // IsId:
+            // currentIndex is at 'z'. Next should be be isId 
+            currentIndex++;
+            isId = new ReadOnlySpan<byte>(key, currentIndex, 1);
+            // currentIndex is at 'IsId'. Next should be 'z', can skip both 'IsId z' to get to o value 
+            currentIndex += 2;
+
+            // O:
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (key[i] == 0)
+                {
+                    oStart = currentIndex;
+                    oLength = i - currentIndex;
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            // currentIdex is at 'z'. Next should be Index 
+            currentIndex++;
+            index = new ReadOnlySpan<byte>(key, currentIndex, BYTES_PER_INT);
+            currentIndex += BYTES_PER_INT + 1; // skipping ahead of index z
+
+            // S:
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (key[i] == 0)
+                {
+                    sStart = currentIndex;
+                    sLength = i - currentIndex;
+                    break;
+                }
+                if (i == key.Length - 1)
+                {
+                    sStart = currentIndex;
+                    sLength = key.Length - currentIndex;
+                    break;
+                }
+            }
+
+            // TokenType:
+            tokenType = new ReadOnlySpan<byte>(value);
+
+            return new Triple(Encoding.UTF8.GetString(key, sStart, sLength), Encoding.UTF8.GetString(key, pStart, pLength), new TripleObject(Encoding.UTF8.GetString(key, oStart, oLength), MemoryMarshal.Read<bool>(isId), (JTokenType)MemoryMarshal.Read<ushort>(tokenType), MemoryMarshal.Read<int>(index)));
+        }
+
+        private static Triple SKVPToTriple(byte[] key, byte[] value)
+        {
+            // name .S z s z p z Index
+            // NAME: 
+            ReadOnlySpan<byte> index;
+            int sStart = 0, sLength = 0, pStart = 0, pLength = 0;
+
+            var dotSSpan = new ReadOnlySpan<byte>(KeyConfig.ByteS);
+            var currentIndex = 0;
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (dotSSpan.SequenceEqual(new ReadOnlySpan<byte>(key, i, 2)))
+                {
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            // S:
+            // currentIndex is at '.' in '.S'. Next should be 'z', can skip both 'Sz' to get to s value
+            currentIndex += 3;
+
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (key[i] == 0)
+                {
+                    sStart = currentIndex;
+                    sLength = i - currentIndex;
+                    currentIndex = i;
+                    break;
+                }
+            }
+            currentIndex++;
+
+            // P:
+            for (var i = currentIndex; i < key.Length; i++)
+            {
+                if (key[i] == 0)
+                {
+                    pStart = currentIndex;
+                    pLength = i - currentIndex;
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            // currentIndex is at 'z'. Next should be Index 
+            currentIndex++;
+            // Index;
+            index = new ReadOnlySpan<byte>(key, currentIndex, key.Length - currentIndex);
+
+            //value = olength o idLength id typeLength type
+
+            currentIndex = 0;
+            var (o, olen) = ReadString(value, currentIndex);
+            currentIndex += BYTES_PER_INT + olen;
+            var (isId, idLen) = ReadBool(value, currentIndex);
+            currentIndex += BYTES_PER_INT + idLen;
+            var (tokenType, _) = ReadUInt16(value, currentIndex);
+
+            return new Triple(Encoding.UTF8.GetString(key, sStart, sLength), Encoding.UTF8.GetString(key, pStart, pLength), new TripleObject(o, isId, (JTokenType)tokenType, MemoryMarshal.Read<int>(index)));
         }
 
         private static byte[] ReadNext(byte[] source, int index)
         {
-            var lenSpan = new ReadOnlySpan<byte>(source, index, 4);
+            var lenSpan = new ReadOnlySpan<byte>(source, index, BYTES_PER_INT);
             var len = MemoryMarshal.Read<int>(lenSpan);
-            var destination = new ReadOnlySpan<byte>(source, index + 4, len);
+            var destination = new ReadOnlySpan<byte>(source, index + BYTES_PER_INT, len);
             return destination.ToArray();
         }
 
         private static (string, int) ReadString(byte[] source, int index)
         {
-            var lenSpan = new ReadOnlySpan<byte>(source, index, 4);
+            var lenSpan = new ReadOnlySpan<byte>(source, index, BYTES_PER_INT);
             var len = MemoryMarshal.Read<int>(lenSpan);
-            return (Encoding.UTF8.GetString(source, index + 4, len), len);
+            return (Encoding.UTF8.GetString(source, index + BYTES_PER_INT, len), len);
         }
 
         private static (bool, int) ReadBool(byte[] source, int index)
         {
-            var valueSpan = new ReadOnlySpan<byte>(source, index + 4, 1);
+            var valueSpan = new ReadOnlySpan<byte>(source, index + BYTES_PER_INT, 1);
             return (MemoryMarshal.Read<bool>(valueSpan), 1);
         }
 
         private static (int, int) ReadInt(byte[] source, int index)
         {
-            var lenSpan = new ReadOnlySpan<byte>(source, index, 4);
+            var lenSpan = new ReadOnlySpan<byte>(source, index, BYTES_PER_INT);
             var len = MemoryMarshal.Read<int>(lenSpan);
-            var valueSpan = new ReadOnlySpan<byte>(source, index + 4, len);
+            var valueSpan = new ReadOnlySpan<byte>(source, index + BYTES_PER_INT, len);
             return (MemoryMarshal.Read<int>(valueSpan), len);
         }
 
         private static (ushort, int) ReadUInt16(byte[] source, int index)
         {
-            var lenSpan = new ReadOnlySpan<byte>(source, index, 4);
+            var lenSpan = new ReadOnlySpan<byte>(source, index, BYTES_PER_INT);
             var len = MemoryMarshal.Read<int>(lenSpan);
-            var valueSpan = new ReadOnlySpan<byte>(source, index + 4, len);
+            var valueSpan = new ReadOnlySpan<byte>(source, index + BYTES_PER_INT, len);
             return (MemoryMarshal.Read<ushort>(valueSpan), len);
         }
 

--- a/Hexastore.Test/Hexastore.Test.csproj
+++ b/Hexastore.Test/Hexastore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Hexastore.Test/RocksFixture.cs
+++ b/Hexastore.Test/RocksFixture.cs
@@ -20,15 +20,16 @@ namespace Hexastore.Test
         public readonly IStoreProcesor StoreProcessor;
         public readonly IStoreOperationFactory StoreOperationFactory;
         public readonly string SetId;
+        public readonly string TestDirectory;
 
         public RocksFixture()
         {
-            const string testDirectory = "./testdata";
-            if (Directory.Exists(testDirectory)) {
-                Directory.Delete(testDirectory, true);
+            TestDirectory = $"./{Guid.NewGuid()}";
+            if (Directory.Exists(TestDirectory)) {
+                Directory.Delete(TestDirectory, true);
             }
-            Directory.CreateDirectory(testDirectory);
-            GraphProvider = new RocksGraphProvider(Mock.Of<ILogger<RocksGraphProvider>>(), testDirectory);
+            Directory.CreateDirectory(TestDirectory);
+            GraphProvider = new RocksGraphProvider(Mock.Of<ILogger<RocksGraphProvider>>(), TestDirectory);
             StoreProvider = new SetProvider(GraphProvider);
             StoreOperationFactory = new StoreOperationFactory();
             StoreProcessor = new StoreProcessor(StoreProvider, new Reasoner(), StoreOperationFactory, Mock.Of<ILogger<StoreProcessor>>());
@@ -38,6 +39,10 @@ namespace Hexastore.Test
         public void Dispose()
         {
             GraphProvider.Dispose();
+            if (Directory.Exists(TestDirectory))
+            {
+                Directory.Delete(TestDirectory, true);
+            }
         }
     }
 }

--- a/Hexastore.Test/RocksFixture.cs
+++ b/Hexastore.Test/RocksFixture.cs
@@ -20,16 +20,12 @@ namespace Hexastore.Test
         public readonly IStoreProcesor StoreProcessor;
         public readonly IStoreOperationFactory StoreOperationFactory;
         public readonly string SetId;
-        public readonly string TestDirectory;
+        public readonly TestFolder TestFolder;
 
         public RocksFixture()
         {
-            TestDirectory = $"./{Guid.NewGuid()}";
-            if (Directory.Exists(TestDirectory)) {
-                Directory.Delete(TestDirectory, true);
-            }
-            Directory.CreateDirectory(TestDirectory);
-            GraphProvider = new RocksGraphProvider(Mock.Of<ILogger<RocksGraphProvider>>(), TestDirectory);
+            TestFolder = new TestFolder();
+            GraphProvider = new RocksGraphProvider(Mock.Of<ILogger<RocksGraphProvider>>(), TestFolder.Root);
             StoreProvider = new SetProvider(GraphProvider);
             StoreOperationFactory = new StoreOperationFactory();
             StoreProcessor = new StoreProcessor(StoreProvider, new Reasoner(), StoreOperationFactory, Mock.Of<ILogger<StoreProcessor>>());
@@ -39,10 +35,7 @@ namespace Hexastore.Test
         public void Dispose()
         {
             GraphProvider.Dispose();
-            if (Directory.Exists(TestDirectory))
-            {
-                Directory.Delete(TestDirectory, true);
-            }
+            TestFolder.Dispose();
         }
     }
 }

--- a/Hexastore.Test/TestFolder.cs
+++ b/Hexastore.Test/TestFolder.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+
+namespace Hexastore.Test
+{
+    /// <summary>
+    /// Temp directory that cleans up on dispose.
+    /// </summary>
+    public class TestFolder : IDisposable
+    {
+        // The actual root
+        private readonly DirectoryInfo _parent;
+
+        public string Root => RootDirectory.FullName;
+
+        /// <summary>
+        /// Delete the directory after completion.
+        /// </summary>
+        public bool CleanUp { get; set; } = true;
+
+        /// <summary>
+        /// Root directory, parent of the working directory
+        /// </summary>
+        public DirectoryInfo RootDirectory { get; }
+
+        public TestFolder()
+        {
+            var parts = Guid.NewGuid().ToString().ToLowerInvariant().Split('-');
+
+            _parent = new DirectoryInfo(Path.Combine(Path.GetTempPath(), parts[0]));
+            _parent.Create();
+
+            File.WriteAllText(Path.Combine(_parent.FullName, "trace.txt"), Environment.StackTrace);
+
+            RootDirectory = new DirectoryInfo(Path.Combine(_parent.FullName, parts[1]));
+            RootDirectory.Create();
+        }
+
+        public static implicit operator string(TestFolder folder)
+        {
+            return folder.Root;
+        }
+
+        public override string ToString()
+        {
+            return Root;
+        }
+
+        public void Dispose()
+        {
+            if (CleanUp)
+            {
+                try
+                {
+                    _parent.Delete(true);
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+}

--- a/Hexastore.Test/TripleTest.cs
+++ b/Hexastore.Test/TripleTest.cs
@@ -167,8 +167,8 @@ namespace Hexastore.Test
         public void GetBy_PO_Returns()
         {
             _set.Assert("s1", "p1", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromId("o3"));
-            _set.Assert("s2", "p1", TripleObject.FromId("o3"));
+            _set.Assert("s1", "p1", TripleObject.FromData("o3"));
+            _set.Assert("s2", "p1", TripleObject.FromData("o3"));
             _set.Assert("s2", "p1", "o2");
             _set.Assert("s3", "p1", "o2");
 
@@ -182,10 +182,10 @@ namespace Hexastore.Test
             Assert.AreEqual(p1o1.Count(), 1);
             CollectionAssert.Contains(p1o1, new Triple("s1", "p1", "o1"));
 
-            var p1o1v = _set.PO("p1", TripleObject.FromData("o3", true)).ToArray();
+            var p1o1v = _set.PO("p1", TripleObject.FromData("o3")).ToArray();
             Assert.AreEqual(p1o1v.Count(), 2);
-            CollectionAssert.Contains(p1o1v, new Triple("s1", "p1", TripleObject.FromId("o3")));
-            CollectionAssert.Contains(p1o1v, new Triple("s2", "p1", TripleObject.FromId("o3")));
+            CollectionAssert.Contains(p1o1v, new Triple("s1", "p1", TripleObject.FromData("o3")));
+            CollectionAssert.Contains(p1o1v, new Triple("s2", "p1", TripleObject.FromData("o3")));
 
             var p3c3 = _set.PO("p3", "c3").ToArray();
             Assert.AreEqual(p3c3.Count(), 1);
@@ -257,7 +257,7 @@ namespace Hexastore.Test
             CollectionAssert.Contains(o1s1, new Triple("s1", "p2", "o1"));
             CollectionAssert.Contains(o1s1, new Triple("s1", "p3", "o1"));
 
-            var o1vs1 = _set.OS(TripleObject.FromData("o2", true), "s1").ToArray();
+            var o1vs1 = _set.OS(TripleObject.FromId("o2"), "s1").ToArray();
             Assert.AreEqual(o1vs1.Count(), 2);
             CollectionAssert.Contains(o1vs1, new Triple("s1", "p1", TripleObject.FromId("o2")));
             CollectionAssert.Contains(o1vs1, new Triple("s1", "p2", TripleObject.FromId("o2")));

--- a/Hexastore.Test/TripleTest.cs
+++ b/Hexastore.Test/TripleTest.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Hexastore.Graph;
 using Hexastore.Processor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -112,7 +112,7 @@ namespace Hexastore.Test
         public void GetBy_P_Returns()
         {
             _set.Assert("s1", "p1", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromData("o2", true));
+            _set.Assert("s1", "p1", TripleObject.FromData("o2"));
             _set.Assert("s2", "p1", "c1");
 
             _set.Assert("s2", "p3", "c2");
@@ -125,7 +125,7 @@ namespace Hexastore.Test
             Assert.AreEqual(byP1.Count(), 3);
             CollectionAssert.Contains(byP1, new Triple("s1", "p1", "o1"));
             CollectionAssert.Contains(byP1, new Triple("s2", "p1", "c1"));
-            CollectionAssert.Contains(byP1, new Triple("s1", "p1", TripleObject.FromData("o2", true)));
+            CollectionAssert.Contains(byP1, new Triple("s1", "p1", TripleObject.FromData("o2")));
 
             var byP3 = _set.P("p3").ToArray();
             Assert.AreEqual(byP3.Count(), 2);
@@ -167,8 +167,8 @@ namespace Hexastore.Test
         public void GetBy_PO_Returns()
         {
             _set.Assert("s1", "p1", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromData("o3", true));
-            _set.Assert("s2", "p1", TripleObject.FromData("o3", true));
+            _set.Assert("s1", "p1", TripleObject.FromId("o3"));
+            _set.Assert("s2", "p1", TripleObject.FromId("o3"));
             _set.Assert("s2", "p1", "o2");
             _set.Assert("s3", "p1", "o2");
 
@@ -184,8 +184,8 @@ namespace Hexastore.Test
 
             var p1o1v = _set.PO("p1", TripleObject.FromData("o3", true)).ToArray();
             Assert.AreEqual(p1o1v.Count(), 2);
-            CollectionAssert.Contains(p1o1v, new Triple("s1", "p1", TripleObject.FromData("o3", true)));
-            CollectionAssert.Contains(p1o1v, new Triple("s2", "p1", TripleObject.FromData("o3", true)));
+            CollectionAssert.Contains(p1o1v, new Triple("s1", "p1", TripleObject.FromId("o3")));
+            CollectionAssert.Contains(p1o1v, new Triple("s2", "p1", TripleObject.FromId("o3")));
 
             var p3c3 = _set.PO("p3", "c3").ToArray();
             Assert.AreEqual(p3c3.Count(), 1);
@@ -202,8 +202,8 @@ namespace Hexastore.Test
         public void GetBy_O_Returns()
         {
             _set.Assert("s1", "p1", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromData("o3", true));
-            _set.Assert("s2", "p1", TripleObject.FromData("o3", true));
+            _set.Assert("s1", "p1", TripleObject.FromId("o3"));
+            _set.Assert("s2", "p1", TripleObject.FromId("o3"));
             _set.Assert("s2", "p1", "o2");
             _set.Assert("s3", "p1", "o2");
 
@@ -217,10 +217,10 @@ namespace Hexastore.Test
             Assert.AreEqual(o1.Count(), 1);
             CollectionAssert.Contains(o1, new Triple("s1", "p1", "o1"));
 
-            var o1v = _set.O(TripleObject.FromData("o3", true)).ToArray();
+            var o1v = _set.O(TripleObject.FromId("o3")).ToArray();
             Assert.AreEqual(o1v.Count(), 2);
-            CollectionAssert.Contains(o1v, new Triple("s1", "p1", TripleObject.FromData("o3", true)));
-            CollectionAssert.Contains(o1v, new Triple("s2", "p1", TripleObject.FromData("o3", true)));
+            CollectionAssert.Contains(o1v, new Triple("s1", "p1", TripleObject.FromId("o3")));
+            CollectionAssert.Contains(o1v, new Triple("s2", "p1", TripleObject.FromId("o3")));
 
             var c3 = _set.O("c3").ToArray();
             Assert.AreEqual(c3.Count(), 1);
@@ -239,9 +239,9 @@ namespace Hexastore.Test
             _set.Assert("s1", "p1", "o1");
             _set.Assert("s1", "p2", "o1");
             _set.Assert("s1", "p3", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromData("o2", true));
-            _set.Assert("s1", "p2", TripleObject.FromData("o2", true));
-            _set.Assert("s2", "p1", TripleObject.FromData("o2", true));
+            _set.Assert("s1", "p1", TripleObject.FromId("o2"));
+            _set.Assert("s1", "p2", TripleObject.FromId("o2"));
+            _set.Assert("s2", "p1", TripleObject.FromId("o2"));
             _set.Assert("s2", "p1", "o2");
             _set.Assert("s3", "p1", "o2");
 
@@ -259,8 +259,8 @@ namespace Hexastore.Test
 
             var o1vs1 = _set.OS(TripleObject.FromData("o2", true), "s1").ToArray();
             Assert.AreEqual(o1vs1.Count(), 2);
-            CollectionAssert.Contains(o1vs1, new Triple("s1", "p1", TripleObject.FromData("o2", true)));
-            CollectionAssert.Contains(o1vs1, new Triple("s1", "p2", TripleObject.FromData("o2", true)));
+            CollectionAssert.Contains(o1vs1, new Triple("s1", "p1", TripleObject.FromId("o2")));
+            CollectionAssert.Contains(o1vs1, new Triple("s1", "p2", TripleObject.FromId("o2")));
 
             var c3s2 = _set.OS("c3", "s2").ToArray();
             Assert.AreEqual(c3s2.Count(), 1);

--- a/Hexastore.Test/TripleTest.cs
+++ b/Hexastore.Test/TripleTest.cs
@@ -112,7 +112,7 @@ namespace Hexastore.Test
         public void GetBy_P_Returns()
         {
             _set.Assert("s1", "p1", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromData("o1"));
+            _set.Assert("s1", "p1", TripleObject.FromData("o2", true));
             _set.Assert("s2", "p1", "c1");
 
             _set.Assert("s2", "p3", "c2");
@@ -125,7 +125,7 @@ namespace Hexastore.Test
             Assert.AreEqual(byP1.Count(), 3);
             CollectionAssert.Contains(byP1, new Triple("s1", "p1", "o1"));
             CollectionAssert.Contains(byP1, new Triple("s2", "p1", "c1"));
-            CollectionAssert.Contains(byP1, new Triple("s1", "p1", TripleObject.FromData("o1")));
+            CollectionAssert.Contains(byP1, new Triple("s1", "p1", TripleObject.FromData("o2", true)));
 
             var byP3 = _set.P("p3").ToArray();
             Assert.AreEqual(byP3.Count(), 2);
@@ -167,8 +167,8 @@ namespace Hexastore.Test
         public void GetBy_PO_Returns()
         {
             _set.Assert("s1", "p1", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromData("o1"));
-            _set.Assert("s2", "p1", TripleObject.FromData("o1"));
+            _set.Assert("s1", "p1", TripleObject.FromData("o3", true));
+            _set.Assert("s2", "p1", TripleObject.FromData("o3", true));
             _set.Assert("s2", "p1", "o2");
             _set.Assert("s3", "p1", "o2");
 
@@ -182,10 +182,10 @@ namespace Hexastore.Test
             Assert.AreEqual(p1o1.Count(), 1);
             CollectionAssert.Contains(p1o1, new Triple("s1", "p1", "o1"));
 
-            var p1o1v = _set.PO("p1", TripleObject.FromData("o1")).ToArray();
+            var p1o1v = _set.PO("p1", TripleObject.FromData("o3", true)).ToArray();
             Assert.AreEqual(p1o1v.Count(), 2);
-            CollectionAssert.Contains(p1o1v, new Triple("s1", "p1", TripleObject.FromData("o1")));
-            CollectionAssert.Contains(p1o1v, new Triple("s2", "p1", TripleObject.FromData("o1")));
+            CollectionAssert.Contains(p1o1v, new Triple("s1", "p1", TripleObject.FromData("o3", true)));
+            CollectionAssert.Contains(p1o1v, new Triple("s2", "p1", TripleObject.FromData("o3", true)));
 
             var p3c3 = _set.PO("p3", "c3").ToArray();
             Assert.AreEqual(p3c3.Count(), 1);
@@ -202,8 +202,8 @@ namespace Hexastore.Test
         public void GetBy_O_Returns()
         {
             _set.Assert("s1", "p1", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromData("o1"));
-            _set.Assert("s2", "p1", TripleObject.FromData("o1"));
+            _set.Assert("s1", "p1", TripleObject.FromData("o3", true));
+            _set.Assert("s2", "p1", TripleObject.FromData("o3", true));
             _set.Assert("s2", "p1", "o2");
             _set.Assert("s3", "p1", "o2");
 
@@ -217,10 +217,10 @@ namespace Hexastore.Test
             Assert.AreEqual(o1.Count(), 1);
             CollectionAssert.Contains(o1, new Triple("s1", "p1", "o1"));
 
-            var o1v = _set.O(TripleObject.FromData("o1")).ToArray();
+            var o1v = _set.O(TripleObject.FromData("o3", true)).ToArray();
             Assert.AreEqual(o1v.Count(), 2);
-            CollectionAssert.Contains(o1v, new Triple("s1", "p1", TripleObject.FromData("o1")));
-            CollectionAssert.Contains(o1v, new Triple("s2", "p1", TripleObject.FromData("o1")));
+            CollectionAssert.Contains(o1v, new Triple("s1", "p1", TripleObject.FromData("o3", true)));
+            CollectionAssert.Contains(o1v, new Triple("s2", "p1", TripleObject.FromData("o3", true)));
 
             var c3 = _set.O("c3").ToArray();
             Assert.AreEqual(c3.Count(), 1);
@@ -239,9 +239,9 @@ namespace Hexastore.Test
             _set.Assert("s1", "p1", "o1");
             _set.Assert("s1", "p2", "o1");
             _set.Assert("s1", "p3", "o1");
-            _set.Assert("s1", "p1", TripleObject.FromData("o1"));
-            _set.Assert("s1", "p2", TripleObject.FromData("o1"));
-            _set.Assert("s2", "p1", TripleObject.FromData("o1"));
+            _set.Assert("s1", "p1", TripleObject.FromData("o2", true));
+            _set.Assert("s1", "p2", TripleObject.FromData("o2", true));
+            _set.Assert("s2", "p1", TripleObject.FromData("o2", true));
             _set.Assert("s2", "p1", "o2");
             _set.Assert("s3", "p1", "o2");
 
@@ -257,10 +257,10 @@ namespace Hexastore.Test
             CollectionAssert.Contains(o1s1, new Triple("s1", "p2", "o1"));
             CollectionAssert.Contains(o1s1, new Triple("s1", "p3", "o1"));
 
-            var o1vs1 = _set.OS(TripleObject.FromData("o1"), "s1").ToArray();
+            var o1vs1 = _set.OS(TripleObject.FromData("o2", true), "s1").ToArray();
             Assert.AreEqual(o1vs1.Count(), 2);
-            CollectionAssert.Contains(o1vs1, new Triple("s1", "p1", TripleObject.FromData("o1")));
-            CollectionAssert.Contains(o1vs1, new Triple("s1", "p2", TripleObject.FromData("o1")));
+            CollectionAssert.Contains(o1vs1, new Triple("s1", "p1", TripleObject.FromData("o2", true)));
+            CollectionAssert.Contains(o1vs1, new Triple("s1", "p2", TripleObject.FromData("o2", true)));
 
             var c3s2 = _set.OS("c3", "s2").ToArray();
             Assert.AreEqual(c3s2.Count(), 1);

--- a/Hexastore/Graph/TripleObject.cs
+++ b/Hexastore/Graph/TripleObject.cs
@@ -188,7 +188,7 @@ namespace Hexastore.Graph
             //}
 
             // NOTE: the ! on !t.IsID == !IsID seems to be necessary as without it, it ends up comparing references and not values
-            return !t.IsID == !IsID && t.Value == Value && t.Index == Index && t.TokenType == TokenType;
+            return !t.IsID == !IsID && t.Index == Index && t.TokenType == TokenType && t.Value == Value;
         }
 
         public override int GetHashCode()

--- a/Hexastore/Graph/TripleObject.cs
+++ b/Hexastore/Graph/TripleObject.cs
@@ -83,11 +83,6 @@ namespace Hexastore.Graph
             return new TripleObject(s, false, JTokenType.String, null);
         }
 
-        public static TripleObject FromData(string s, bool isId)
-        {
-            return new TripleObject(s, isId, JTokenType.String, null);
-        }
-
         public static TripleObject FromData(string s, int index)
         {
             return new TripleObject(s, false, JTokenType.String, index);

--- a/Hexastore/Graph/TripleObject.cs
+++ b/Hexastore/Graph/TripleObject.cs
@@ -83,6 +83,11 @@ namespace Hexastore.Graph
             return new TripleObject(s, false, JTokenType.String, null);
         }
 
+        public static TripleObject FromData(string s, bool isId)
+        {
+            return new TripleObject(s, isId, JTokenType.String, null);
+        }
+
         public static TripleObject FromData(string s, int index)
         {
             return new TripleObject(s, false, JTokenType.String, index);
@@ -182,7 +187,8 @@ namespace Hexastore.Graph
             //    return t.IsID == IsID && t.Value == Value && t.TokenType == TokenType;
             //}
 
-            return t.IsID == IsID && t.Value == Value && t.Index == Index && t.TokenType == TokenType;
+            // NOTE: the ! on !t.IsID == !IsID seems to be necessary as without it, it ends up comparing references and not values
+            return !t.IsID == !IsID && t.Value == Value && t.Index == Index && t.TokenType == TokenType;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
This change removes duplication in the key value pairs for the S, P, and O keys by only storing the properties of each triple in the value field that are not already part of the key. Then for each respective KVP, we are able to parse the key and value bytes to reconstruct each triple.  