### PR TITLE
Update to dotnet 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -21,7 +21,7 @@ RUN dotnet test Hexastore.Test
 RUN dotnet publish -c Release ./Hexastore.Web -o /app/out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
 COPY --from=build-env /app/out .
 
@@ -30,6 +30,6 @@ RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \
     ln -s /lib/x86_64-linux-gnu/libc.so.6 /usr/lib/x86_64-linux-gnu/libc.so && \
     rm -rf /var/lib/apt/lists/*
 
-ENV ENV LD_LIBRARY_PATH=ENV LD_LIBRARY_PATH:/app/bin/Debug/netcoreapp2.2/native/amd64/:/app/bin/Release/netcoreapp2.2/native/amd64/
+ENV ENV LD_LIBRARY_PATH=ENV LD_LIBRARY_PATH:/app/bin/Debug/netcoreapp3.1/native/amd64/:/app/bin/Release/netcoreapp3.1/native/amd64/
 EXPOSE 80
 ENTRYPOINT ["dotnet", "Hexastore.Web.dll"]

--- a/Hexastore.PerfConsole/Hexastore.PerfConsole.csproj
+++ b/Hexastore.PerfConsole/Hexastore.PerfConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
 

--- a/Hexastore.Test/Hexastore.Test.csproj
+++ b/Hexastore.Test/Hexastore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Hexastore.Web/Hexastore.Web.csproj
+++ b/Hexastore.Web/Hexastore.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
@@ -15,12 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="dotenv.net" Version="1.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.0.2105168" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
   </ItemGroup>
 

--- a/Hexastore.Web/Startup.cs
+++ b/Hexastore.Web/Startup.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
 
 namespace Hexastore.Web
 {
@@ -26,20 +28,19 @@ namespace Hexastore.Web
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            // services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-            services.AddCors(options =>
-            {
+            services.AddCors(options => {
                 options.AddPolicy("AllowAnyOrigin",
                     builder => builder
                         .AllowAnyOrigin()
                         .AllowAnyMethod()
                         .WithExposedHeaders("content-disposition")
                         .AllowAnyHeader()
-                        .AllowCredentials()
                         .SetPreflightMaxAge(TimeSpan.FromSeconds(3600)));
             });
 
-            services.AddMvc();
+
+            services.AddControllers().AddNewtonsoftJson();
+
             services.AddSingleton<IGraphProvider, RocksGraphProvider>();
             services.AddSingleton<IReasoner, Reasoner>();
             services.AddSingleton<IStoreProcesor, StoreProcessor>();
@@ -54,7 +55,7 @@ namespace Hexastore.Web
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (File.Exists("/var/data/Hexastore.env")) {
                 DotEnv.Config(false, "/var/data/Hexastore.env");
@@ -68,7 +69,14 @@ namespace Hexastore.Web
             app.UseCors("AllowAnyOrigin");
 
             app.UseMiddleware<PerfHeaderMiddleware>();
-            app.UseMvc();
+
+            // app.UseHttpsRedirection();
+            // app.UseAuthorization();
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints => {
+                endpoints.MapControllers();
+            });
         }
     }
 }

--- a/Hexastore/Hexastore.csproj
+++ b/Hexastore/Hexastore.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
I've updated Hexastore.Web from netcoreapp2.2 to netcoreapp3.1 and migrated over the MVC configuration. 

The settings are based on the migration guide, and what you get when creating a new 3.1 MVC project. I've verified that adding and querying data works locally for me.

MVCs changes around newtonsoft.json were particularly painful, but it now works using `Microsoft.AspNetCore.Mvc.NewtonsoftJson` which is the recommended way to handle this in the migration guide.

We should see perf improvements using 3.1. 2.2 is considered dead at this point, the 2.x LTS is 2.1.